### PR TITLE
Issue 50: Make schema registry client autoclosable and add namespace to factory method

### DIFF
--- a/client/src/main/java/io/pravega/schemaregistry/client/SchemaRegistryClient.java
+++ b/client/src/main/java/io/pravega/schemaregistry/client/SchemaRegistryClient.java
@@ -38,7 +38,7 @@ import static io.pravega.schemaregistry.client.exceptions.RegistryExceptions.Mal
  * The implementation of this interface should provide read-after-write-consistency guarantees for all the methods.
  */
 @Beta
-public interface SchemaRegistryClient {
+public interface SchemaRegistryClient extends AutoCloseable {
     /**
      * Adds a new group. A group refers to the name under which the schemas are registered. A group is identified by a 
      * unique id and has an associated set of group metadata {@link GroupProperties} and a list of codec types and a 

--- a/client/src/main/java/io/pravega/schemaregistry/client/SchemaRegistryClientConfig.java
+++ b/client/src/main/java/io/pravega/schemaregistry/client/SchemaRegistryClientConfig.java
@@ -24,14 +24,12 @@ public class SchemaRegistryClientConfig {
      * URI for connecting with registry client.
      */
     private final URI schemaRegistryUri;
-    private final String namespace;
     private final boolean authEnabled;
     private final String authMethod;
     private final String authToken;
 
-    private SchemaRegistryClientConfig(URI schemaRegistryUri, String namespace, boolean authEnabled, String authMethod, String authToken) {
+    private SchemaRegistryClientConfig(URI schemaRegistryUri, boolean authEnabled, String authMethod, String authToken) {
         this.schemaRegistryUri = schemaRegistryUri;
-        this.namespace = namespace;
         this.authEnabled = authEnabled;
         this.authMethod = authMethod;
         this.authToken = authToken;
@@ -39,6 +37,5 @@ public class SchemaRegistryClientConfig {
 
     public static final class SchemaRegistryClientConfigBuilder {
         private boolean authEnabled = false;
-        private String namespace = null;
     }
 }

--- a/client/src/main/java/io/pravega/schemaregistry/client/SchemaRegistryClientFactory.java
+++ b/client/src/main/java/io/pravega/schemaregistry/client/SchemaRegistryClientFactory.java
@@ -14,12 +14,25 @@ package io.pravega.schemaregistry.client;
  */
 public class SchemaRegistryClientFactory {
     /**
-     * Factory method to create Schema Registry Client.
+     * Factory method to create Schema Registry Client with default namespace.
+     * This sets the namespace context to use the default namespace (no namespace). 
      * 
      * @param config Configuration for creating registry client. 
      * @return SchemaRegistry client implementation
      */
-    public static SchemaRegistryClient createRegistryClient(SchemaRegistryClientConfig config) {
-        return new SchemaRegistryClientImpl(config);
+    public static SchemaRegistryClient withDefaultNamespace(SchemaRegistryClientConfig config) {
+        return new SchemaRegistryClientImpl(config, null);
+    }
+    
+    /**
+     * Factory method to create Schema Registry Client with namespace. 
+     * This sets the namespace context for all calls to registry service. 
+     * 
+     * @param config Configuration for creating registry client. 
+     * @param namespace Namespace 
+     * @return SchemaRegistry client implementation
+     */
+    public static SchemaRegistryClient withNamespace(String namespace, SchemaRegistryClientConfig config) {
+        return new SchemaRegistryClientImpl(config, namespace);
     }
 }


### PR DESCRIPTION
Signed-off-by: Shivesh Ranjan <shivesh.ranjan@gmail.com>

**Change log description**  
Makes schema registry client auto closable.
Adds namespace as a factory method param rather than a config param so that users are explicitly aware of the namespace with which they are creating a client. 

**Purpose of the change**  
Fixes #50 

**What the code does**  
Adds new factory method that takes the namespace rather than taking it from the ClientConfig. 


**How to verify it**  
NA