### PR TITLE
Issue 55: Support for Json schema draft 4 to 7

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -85,7 +85,7 @@ allprojects {
             url "https://repository.apache.org/snapshots"
         }
         maven {
-            url 'https://jitpack.io'
+            url 'https://repository.mulesoft.org/nexus/content/repositories/public'
         }
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -84,6 +84,9 @@ allprojects {
         maven {
             url "https://repository.apache.org/snapshots"
         }
+        maven {
+            url 'https://jitpack.io'
+        }
     }
 
     gradle.projectsEvaluated {
@@ -260,6 +263,7 @@ project('server') {
         compile group: 'com.google.protobuf', name: 'protobuf-java-util', version: protobufUtilVersion
         compile group: 'com.google.protobuf', name: 'protobuf-java', version: protobufProtocVersion
         compile group: 'com.fasterxml.jackson.module', name: 'jackson-module-jsonSchema', version: jacksonVersion
+        compile group: 'com.github.everit-org.json-schema', name: 'org.everit.json.schema', version: everitVersion
         testCompile (group: 'io.pravega', name: 'pravega-standalone', version: pravegaVersion) {
             exclude group: 'javax.ws.rs', module: 'jsr311-api'
         }

--- a/checkstyle/import-control.xml
+++ b/checkstyle/import-control.xml
@@ -43,6 +43,8 @@
     <allow pkg="com.spotify" />
     <allow pkg="io.jsonwebtoken" />
     <allow pkg="io.kubernetes" />
+    <allow pkg="org.json" />
+    <allow pkg="org.everit.json" />
     <allow pkg="org.xerial.snappy" />
 
 </import-control>

--- a/gradle.properties
+++ b/gradle.properties
@@ -27,6 +27,7 @@ gradleSshPluginVersion=2.9.0
 guavaVersion=28.1-jre
 javaxServletApiVersion=4.0.0
 jacksonVersion=2.10.3
+everitVersion=1.12.1
 javaxwsrsApiVersion=2.1
 jaxbVersion=2.3.0
 javaxAnnotationVersion=1.3.2

--- a/server/src/main/java/io/pravega/schemaregistry/service/SchemaRegistryService.java
+++ b/server/src/main/java/io/pravega/schemaregistry/service/SchemaRegistryService.java
@@ -47,6 +47,7 @@ import io.pravega.schemaregistry.storage.StoreExceptions;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.avro.Schema;
 import org.everit.json.schema.loader.SchemaLoader;
+import org.everit.json.schema.loader.SpecificationVersion;
 import org.json.JSONObject;
 import org.json.JSONTokener;
 
@@ -887,8 +888,12 @@ public class SchemaRegistryService {
 
     private void validateJsonSchema4Onward(String schemaString) {
         JSONObject rawSchema = new JSONObject(new JSONTokener(schemaString));
-        // draft 4 to 7
-        if (rawSchema.has("id")) {
+        // we will check if the schema has "id" then it is definitely version 4.
+        // if $schema draft is specified, the schemaloader will automatically use the correct specification version
+        // however, $schema is not mandatory. So we will check with presence of id and if id is specified with draft 4
+        // specification, then we use draft 4, else we will use draft 7 as other keywords are added in draft 7.
+        // Changes between draft 4 and 6/7  https://json-schema.org/draft-06/json-schema-release-notes.html
+        if (rawSchema.has(SpecificationVersion.DRAFT_4.idKeyword())) {
             SchemaLoader.builder().useDefaults(true).schemaJson(rawSchema)
                         .build().load().build();
         } else {

--- a/server/src/main/java/io/pravega/schemaregistry/service/SchemaRegistryService.java
+++ b/server/src/main/java/io/pravega/schemaregistry/service/SchemaRegistryService.java
@@ -882,17 +882,22 @@ public class SchemaRegistryService {
             // try parsing the schema with everit library which supports drafts 4 6 and 7. 
             OBJECT_MAPPER.readValue(schemaString, JsonSchema.class);
         } catch (JsonProcessingException e) {
-            e.printStackTrace();
+            validateJsonSchema4Onward(schemaString);
         }
     }
 
+    /**
+     * This method checks if the schema is well formed according to draft v4 onward. 
+     * Changes between draft 4 and 6/7 https://json-schema.org/draft-06/json-schema-release-notes.html
+     * 
+     * @param schemaString Schema string to validate
+     */
     private void validateJsonSchema4Onward(String schemaString) {
         JSONObject rawSchema = new JSONObject(new JSONTokener(schemaString));
-        // we will check if the schema has "id" then it is definitely version 4.
+        // It will check if the schema has "id" then it is definitely version 4.
         // if $schema draft is specified, the schemaloader will automatically use the correct specification version
         // however, $schema is not mandatory. So we will check with presence of id and if id is specified with draft 4
         // specification, then we use draft 4, else we will use draft 7 as other keywords are added in draft 7.
-        // Changes between draft 4 and 6/7  https://json-schema.org/draft-06/json-schema-release-notes.html
         if (rawSchema.has(SpecificationVersion.DRAFT_4.idKeyword())) {
             SchemaLoader.builder().useDefaults(true).schemaJson(rawSchema)
                         .build().load().build();

--- a/server/src/main/java/io/pravega/schemaregistry/service/SchemaRegistryService.java
+++ b/server/src/main/java/io/pravega/schemaregistry/service/SchemaRegistryService.java
@@ -9,6 +9,7 @@
  */
 package io.pravega.schemaregistry.service;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -862,7 +863,7 @@ public class SchemaRegistryService {
                 default:
                     break;
             }
-        } catch (Exception e) {
+        } catch (IOException | RuntimeException e) {
             log.debug("unable to parse schema {}", e.getMessage());
             isValid = false;
             invalidityCause = "Unable to parse schema";
@@ -879,12 +880,12 @@ public class SchemaRegistryService {
             // jackson JsonSchema only supports json draft 3. If the schema definition is not compatible with draft 3, 
             // try parsing the schema with everit library which supports drafts 4 6 and 7. 
             OBJECT_MAPPER.readValue(schemaString, JsonSchema.class);
-        } catch (IOException e) {
-            handleDraft4onward(schemaString);
+        } catch (JsonProcessingException e) {
+            e.printStackTrace();
         }
     }
 
-    private void handleDraft4onward(String schemaString) {
+    private void validateJsonSchema4Onward(String schemaString) {
         JSONObject rawSchema = new JSONObject(new JSONTokener(schemaString));
         // draft 4 to 7
         if (rawSchema.has("id")) {

--- a/server/src/main/java/io/pravega/schemaregistry/service/SchemaRegistryService.java
+++ b/server/src/main/java/io/pravega/schemaregistry/service/SchemaRegistryService.java
@@ -849,7 +849,9 @@ public class SchemaRegistryService {
                 case Json:
                     schemaString = new String(schemaInfo.getSchemaData().array(), Charsets.UTF_8);
                     validateJsonSchema(schemaString);
-                    // normalize json schema string
+                    // normalize json schema string by parsing it into JsonNode and then serializing it with fields 
+                    // in alphabetical order. This ensures that identical schemas with different order of fields are 
+                    // treated to be equal. 
                     JsonNode jsonNode = OBJECT_MAPPER.readTree(schemaString);
                     schemaBinary = ByteBuffer.wrap(OBJECT_MAPPER.writeValueAsString(jsonNode).getBytes(Charsets.UTF_8));
                     break;
@@ -872,8 +874,8 @@ public class SchemaRegistryService {
     }
 
     private void validateJsonSchema(String schemaString) {
-        // 1. try draft 3
         try {
+            // 1. try draft 3
             // jackson JsonSchema only supports json draft 3. If the schema definition is not compatible with draft 3, 
             // try parsing the schema with everit library which supports drafts 4 6 and 7. 
             OBJECT_MAPPER.readValue(schemaString, JsonSchema.class);

--- a/server/src/main/java/io/pravega/schemaregistry/service/SchemaRegistryService.java
+++ b/server/src/main/java/io/pravega/schemaregistry/service/SchemaRegistryService.java
@@ -862,7 +862,7 @@ public class SchemaRegistryService {
                 default:
                     break;
             }
-        } catch (IOException e) {
+        } catch (Exception e) {
             log.debug("unable to parse schema {}", e.getMessage());
             isValid = false;
             invalidityCause = "Unable to parse schema";
@@ -880,9 +880,18 @@ public class SchemaRegistryService {
             // try parsing the schema with everit library which supports drafts 4 6 and 7. 
             OBJECT_MAPPER.readValue(schemaString, JsonSchema.class);
         } catch (IOException e) {
-            JSONObject rawSchema = new JSONObject(new JSONTokener(schemaString));
-            // draft 4 to 7
-            SchemaLoader.builder().useDefaults(true).draftV7Support().schemaJson(rawSchema)
+            handleDraft4onward(schemaString);
+        }
+    }
+
+    private void handleDraft4onward(String schemaString) {
+        JSONObject rawSchema = new JSONObject(new JSONTokener(schemaString));
+        // draft 4 to 7
+        if (rawSchema.has("id")) {
+            SchemaLoader.builder().useDefaults(true).schemaJson(rawSchema)
+                        .build().load().build();
+        } else {
+            SchemaLoader.builder().useDefaults(true).schemaJson(rawSchema).draftV7Support()
                         .build().load().build();
         }
     }


### PR DESCRIPTION
Signed-off-by: Shivesh Ranjan <shivesh.ranjan@gmail.com>

**Change log description**  
Use everit.json.SchemaLoader to parse the json schema to verify that it is supported for schemas that follow draft specifications from 4 6 or 7.

**Purpose of the change**  
Fixes #55 

**What the code does**  
Jackson's JsonSchema module supports Json schema draft 3. Draft 4 to 7 have some additional incompatible changes. JsonSchema is not able to parse a schema which conforms to versions 4 to 7 if they use any keywords that is not present in draft 3. 

So we first try to parse the schema using JsonSchema and if it fails, we attempt to parse it using SchemaLoader. 
If both fail, the schema is considered invalid. 

**How to verify it**  
TBD