### PR TITLE
Issue 61: Exposing schema registry as an ingress

### DIFF
--- a/charts/schema-registry/README.md
+++ b/charts/schema-registry/README.md
@@ -54,6 +54,11 @@ The following table lists the configurable parameters of the schema registry cha
 | `image.pullPolicy` | Pull policy for schema registry image | `IfNotPresent` |
 | `service.type` | Schema registry service type | `LoadBalancer` |
 | `service.port` | Schema registry service port | `9092` |
+| `ingress.enabled` | Whether to expose as an ingress resource | `false` |
+| `ingress.path` | Path for the ingress | `/` |
+| `ingress.annotations` | Annotations for the ingress | `{}` |
+| `ingress.hosts` | List of hosts for the ingress | `[schema-registry.pravega.com]` |
+| `ingress.tls` | TLS configuration for the ingress | `[]` |
 | `controllerUri` | URL of the Pravega Controller service | `tcp://localhost:9090` |
 | `storeType` | Type of store to be used | `Pravega` |
 | `serviceAccount.create` | Whether to create a service account | `true` |

--- a/charts/schema-registry/templates/ingress.yaml
+++ b/charts/schema-registry/templates/ingress.yaml
@@ -1,3 +1,13 @@
+# /**
+#  * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
+#  *
+#  * Licensed under the Apache License, Version 2.0 (the "License");
+#  * you may not use this file except in compliance with the License.
+#  * You may obtain a copy of the License at
+#  *
+#  *     http://www.apache.org/licenses/LICENSE-2.0
+#  */
+
 {{- $ingress := .Values.ingress -}}
 {{- $svc := .Values.service -}}
 {{- if $ingress.enabled -}}

--- a/charts/schema-registry/templates/ingress.yaml
+++ b/charts/schema-registry/templates/ingress.yaml
@@ -1,0 +1,33 @@
+{{- $ingress := .Values.ingress -}}
+{{- $svc := .Values.service -}}
+{{- if $ingress.enabled -}}
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: {{ template "schema-registry.fullname" . }}
+  labels:
+{{ include "schema-registry.commonLabels" . | indent 4 }}
+  annotations:
+{{ toYaml $ingress.annotations | indent 4 }}
+spec:
+  {{- if $ingress.tls }}
+  tls:
+    {{- range $ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range $ingress.hosts }}
+    - host: {{ . }}
+      http:
+        paths:
+          - path: {{ $ingress.path }}
+            backend:
+              serviceName: {{ template "schema-registry.fullname" $ }}
+              servicePort: {{ $svc.port }}
+    {{- end }}
+{{- end }}

--- a/charts/schema-registry/values.yaml
+++ b/charts/schema-registry/values.yaml
@@ -29,6 +29,24 @@ service:
   type: LoadBalancer
   port: 9092
 
+## Ingress configuration.
+ingress:
+  enabled: false
+  path: /
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+
+  ## List of hosts for the ingress
+  hosts:
+    - schema-registry.pravega.com
+
+  ## TLS configuration
+  tls: []
+   # - secretName: schema-registry-tls
+   #   hosts:
+   #     - schema-registry.pravega.com
+   
 client:
   loadDynamic: false
   method: ""
@@ -37,10 +55,10 @@ client:
 storeType: Pravega
 controllerUri: tcp://localhost:9090
 pravega:
-  ## following values should be configured if TLS is required for 
-  ## talking to pravega and we want to perform server auth certificate 
-  ## validation 
-  tlsTrustStore: 
+  ## following values should be configured if TLS is required for
+  ## talking to pravega and we want to perform server auth certificate
+  ## validation
+  tlsTrustStore:
   validateHostName: true
 
 authentication:
@@ -49,7 +67,7 @@ authentication:
   ## authentication is enabled
   passwordAuthSecret:
   userPasswordFile:
-  authorizationResourceQualifier: "" 
+  authorizationResourceQualifier: ""
   disableBasicAuthentication: false
 
 tls:


### PR DESCRIPTION
Signed-off-by: SrishT <Srishti.Thakkar@dell.com>

**Change log description**  
Provides the users with the option of exposing schema registry as an ingress resource as well.

**Purpose of the change**  
Fixes #61 

**How to verify it**  
Install schema registry with ingress enabled using the following command
```
$helm install sr charts/schema-registry --set ingress.enabled=true
```
This would create the ingress resource as we can see with the following command
```
$ kubectl get ingress
NAME                 HOSTS                         ADDRESS        PORTS   AGE
sr-schema-registry   schema-registry.pravega.com   10.243.39.70   80      23s
```