### PR TITLE
Issue 82: Specify schema registry repo in maven.gradle and remove pravega prefix 

### DIFF
--- a/gradle/maven.gradle
+++ b/gradle/maven.gradle
@@ -39,15 +39,15 @@ plugins.withId('maven') {
                     }
                 }
 
-                pom.artifactId = "pravega" + project.path.replace(':', '-')
+                pom.artifactId = project.path.replace(':', '-')
                 pom.project {
                     name "Pravega"
                     url "http://pravega.io"
                     description "Streaming Storage Platform"
                     scm {
-                        url 'https://github.com/pravega/pravega/tree/master'
-                        connection 'scm:git:git://github.com/pravega/pravega.git'
-                        developerConnection 'scm:git:https://github.com/pravega/pravega.git'
+                        url 'https://github.com/pravega/schema-registry/tree/master'
+                        connection 'scm:git:git://github.com/pravega/schema-registry.git'
+                        developerConnection 'scm:git:https://github.com/pravega/schema-registry.git'
                     }
                     licenses {
                         license {
@@ -56,6 +56,9 @@ plugins.withId('maven') {
                         }
                     }
                     developers {
+                        developer {
+                            id 'shiveshr'
+                            name 'Shivesh Ranjan'
                         developer {
                             id 'fpj'
                             name 'Flavio Junqueira'
@@ -76,7 +79,7 @@ plugins.withId('maven') {
     install {
         repositories {
             mavenInstaller {
-                pom.artifactId = "pravega" + project.path.replace(':', '-')
+                pom.artifactId = project.path.replace(':', '-')
             }
         }
     }

--- a/gradle/maven.gradle
+++ b/gradle/maven.gradle
@@ -59,6 +59,7 @@ plugins.withId('maven') {
                         developer {
                             id 'shiveshr'
                             name 'Shivesh Ranjan'
+                        }
                         developer {
                             id 'fpj'
                             name 'Flavio Junqueira'

--- a/gradle/maven.gradle
+++ b/gradle/maven.gradle
@@ -39,7 +39,7 @@ plugins.withId('maven') {
                     }
                 }
 
-                pom.artifactId = project.path.replace(':', '-')
+                pom.artifactId = project.path.replace(':', '')
                 pom.project {
                     name "Pravega"
                     url "http://pravega.io"
@@ -80,7 +80,7 @@ plugins.withId('maven') {
     install {
         repositories {
             mavenInstaller {
-                pom.artifactId = project.path.replace(':', '-')
+                pom.artifactId = project.path.replace(':', '')
             }
         }
     }


### PR DESCRIPTION
Signed-off-by: Shivesh Ranjan <shivesh.ranjan@gmail.com>

**Change log description**  
Fix maven.gradle with schema registry info and remove pravega prefix from artifacts

**Purpose of the change**  
Fixes #82 

**What the code does**  
1. removes "pravega" prefix before the artifactid. 
2. change the source control to give schema registry repo uri

**How to verify it**  
(Optional: steps to verify that the changes are effective)
