### PR TITLE
Issue 89: Fix bug in service config for configuring tls certificate and password file paths

### DIFF
--- a/server/src/main/java/io/pravega/schemaregistry/server/rest/RestServer.java
+++ b/server/src/main/java/io/pravega/schemaregistry/server/rest/RestServer.java
@@ -76,7 +76,7 @@ public class RestServer extends AbstractIdleService {
             log.info("Starting REST server listening on port: {}", this.restServerConfig.getPort());
             if (restServerConfig.isTlsEnabled()) {
                 SSLContextConfigurator contextConfigurator = new SSLContextConfigurator();
-                contextConfigurator.setKeyStoreFile(restServerConfig.getServerKeyStoreFilePath());
+                contextConfigurator.setKeyStoreFile(restServerConfig.getTlsKeyStoreFilePath());
                 contextConfigurator.setKeyStorePass(JKSHelper.loadPasswordFrom(restServerConfig.getTlsKeyStorePasswordFilePath()));
                 httpServer = GrizzlyHttpServerFactory.createHttpServer(baseUri, resourceConfig, true,
                         new SSLEngineConfigurator(contextConfigurator, false, false, false));

--- a/server/src/main/java/io/pravega/schemaregistry/server/rest/ServiceConfig.java
+++ b/server/src/main/java/io/pravega/schemaregistry/server/rest/ServiceConfig.java
@@ -39,9 +39,14 @@ public class ServiceConfig implements ServerConfig {
                           String tlsKeyStoreFilePath, String tlsKeyStorePasswordFilePath, boolean authEnabled, String userPasswordFilePath) {
         Exceptions.checkNotNullOrEmpty(host, "host");
         Exceptions.checkArgument(port > 0, "port", "Should be positive integer");
-        Exceptions.checkArgument(!tlsEnabled || (!Strings.isNullOrEmpty(tlsCertFilePath) &&
-                        !Strings.isNullOrEmpty(tlsKeyStoreFilePath) && !Strings.isNullOrEmpty(tlsKeyStorePasswordFilePath)), "keyFilePath", 
-                "If tls is enabled then key file path and key file password path should be non empty");
+        Exceptions.checkArgument(!tlsEnabled || !Strings.isNullOrEmpty(tlsCertFilePath), "keyCertPath", 
+                "If tls is enabled then cert file path should be non empty");
+        Exceptions.checkArgument(!tlsEnabled || !Strings.isNullOrEmpty(tlsCertFilePath), "keyCertPath", 
+                "If tls is enabled then cert file path should be non empty");
+        Exceptions.checkArgument(!tlsEnabled || !Strings.isNullOrEmpty(tlsKeyStoreFilePath), "keyFilePath", 
+                "If tls is enabled then key file path should be non empty");
+        Exceptions.checkArgument(!tlsEnabled || !Strings.isNullOrEmpty(tlsKeyStorePasswordFilePath), "keyPasswordFilePath", 
+                "If tls is enabled then key file password path should be non empty");
         this.host = host;
         this.port = port;
         this.tlsEnabled = tlsEnabled;

--- a/server/src/main/java/io/pravega/schemaregistry/server/rest/ServiceConfig.java
+++ b/server/src/main/java/io/pravega/schemaregistry/server/rest/ServiceConfig.java
@@ -28,7 +28,7 @@ public class ServiceConfig implements ServerConfig {
     @ToString.Exclude
     private final String tlsCertFilePath;
     @ToString.Exclude
-    private final String serverKeyStoreFilePath;
+    private final String tlsKeyStoreFilePath;
     @ToString.Exclude
     private final String tlsKeyStorePasswordFilePath;
     private final boolean authEnabled;
@@ -36,17 +36,17 @@ public class ServiceConfig implements ServerConfig {
     private final String userPasswordFilePath;
 
     private ServiceConfig(String host, int port, boolean tlsEnabled, String tlsCertFilePath, 
-                          String serverKeyStoreFilePath, String tlsKeyStorePasswordFilePath, boolean authEnabled, String userPasswordFilePath) {
+                          String tlsKeyStoreFilePath, String tlsKeyStorePasswordFilePath, boolean authEnabled, String userPasswordFilePath) {
         Exceptions.checkNotNullOrEmpty(host, "host");
         Exceptions.checkArgument(port > 0, "port", "Should be positive integer");
         Exceptions.checkArgument(!tlsEnabled || (!Strings.isNullOrEmpty(tlsCertFilePath) &&
-                        !Strings.isNullOrEmpty(serverKeyStoreFilePath) && !Strings.isNullOrEmpty(tlsKeyStorePasswordFilePath)), "keyFilePath", 
+                        !Strings.isNullOrEmpty(tlsKeyStoreFilePath) && !Strings.isNullOrEmpty(tlsKeyStorePasswordFilePath)), "keyFilePath", 
                 "If tls is enabled then key file path and key file password path should be non empty");
         this.host = host;
         this.port = port;
         this.tlsEnabled = tlsEnabled;
         this.tlsCertFilePath = tlsCertFilePath;
-        this.serverKeyStoreFilePath = serverKeyStoreFilePath;
+        this.tlsKeyStoreFilePath = tlsKeyStoreFilePath;
         this.tlsKeyStorePasswordFilePath = tlsKeyStorePasswordFilePath;
         this.authEnabled = authEnabled;
         this.userPasswordFilePath = userPasswordFilePath;

--- a/server/src/main/java/io/pravega/schemaregistry/server/rest/ServiceConfig.java
+++ b/server/src/main/java/io/pravega/schemaregistry/server/rest/ServiceConfig.java
@@ -40,7 +40,7 @@ public class ServiceConfig implements ServerConfig {
         Exceptions.checkNotNullOrEmpty(host, "host");
         Exceptions.checkArgument(port > 0, "port", "Should be positive integer");
         Exceptions.checkArgument(!tlsEnabled || (!Strings.isNullOrEmpty(tlsCertFilePath) &&
-                        !Strings.isNullOrEmpty(serverKeyStoreFilePath)), "keyFilePath", 
+                        !Strings.isNullOrEmpty(serverKeyStoreFilePath) && !Strings.isNullOrEmpty(tlsKeyStorePasswordFilePath)), "keyFilePath", 
                 "If tls is enabled then key file path and key file password path should be non empty");
         this.host = host;
         this.port = port;

--- a/server/src/main/java/io/pravega/schemaregistry/server/rest/ServiceConfig.java
+++ b/server/src/main/java/io/pravega/schemaregistry/server/rest/ServiceConfig.java
@@ -39,14 +39,14 @@ public class ServiceConfig implements ServerConfig {
                           String tlsKeyStoreFilePath, String tlsKeyStorePasswordFilePath, boolean authEnabled, String userPasswordFilePath) {
         Exceptions.checkNotNullOrEmpty(host, "host");
         Exceptions.checkArgument(port > 0, "port", "Should be positive integer");
-        Exceptions.checkArgument(!tlsEnabled || !Strings.isNullOrEmpty(tlsCertFilePath), "keyCertPath", 
-                "If tls is enabled then cert file path should be non empty");
-        Exceptions.checkArgument(!tlsEnabled || !Strings.isNullOrEmpty(tlsCertFilePath), "keyCertPath", 
-                "If tls is enabled then cert file path should be non empty");
-        Exceptions.checkArgument(!tlsEnabled || !Strings.isNullOrEmpty(tlsKeyStoreFilePath), "keyFilePath", 
-                "If tls is enabled then key file path should be non empty");
-        Exceptions.checkArgument(!tlsEnabled || !Strings.isNullOrEmpty(tlsKeyStorePasswordFilePath), "keyPasswordFilePath", 
-                "If tls is enabled then key file password path should be non empty");
+        if (tlsEnabled) {
+            Exceptions.checkArgument(!Strings.isNullOrEmpty(tlsCertFilePath), "keyCertPath",
+                    "If tls is enabled then cert file path should be non empty");
+            Exceptions.checkArgument(!Strings.isNullOrEmpty(tlsKeyStoreFilePath), "keyFilePath",
+                    "If tls is enabled then key file path should be non empty");
+            Exceptions.checkArgument(!Strings.isNullOrEmpty(tlsKeyStorePasswordFilePath), "keyPasswordFilePath",
+                    "If tls is enabled then key file password path should be non empty");
+        }
         this.host = host;
         this.port = port;
         this.tlsEnabled = tlsEnabled;

--- a/server/src/main/java/io/pravega/schemaregistry/service/Config.java
+++ b/server/src/main/java/io/pravega/schemaregistry/service/Config.java
@@ -218,7 +218,7 @@ public final class Config {
                                    .userPasswordFilePath(Config.USER_PASSWORD_FILE)
                                    .tlsEnabled(Config.TLS_ENABLED)
                                    .tlsCertFilePath(Config.TLS_CERT_FILE)
-                                   .serverKeyStoreFilePath(Config.TLS_KEY_FILE)
+                                   .tlsKeyStoreFilePath(Config.TLS_KEY_FILE)
                                    .tlsKeyStorePasswordFilePath(Config.TLS_KEY_PASSWORD_FILE)
                                    .build();
     }

--- a/server/src/main/java/io/pravega/schemaregistry/service/Config.java
+++ b/server/src/main/java/io/pravega/schemaregistry/service/Config.java
@@ -219,7 +219,7 @@ public final class Config {
                                    .tlsEnabled(Config.TLS_ENABLED)
                                    .tlsCertFilePath(Config.TLS_CERT_FILE)
                                    .serverKeyStoreFilePath(Config.TLS_KEY_FILE)
-                                   .serverKeyStoreFilePath(Config.TLS_KEY_PASSWORD_FILE)
+                                   .tlsKeyStorePasswordFilePath(Config.TLS_KEY_PASSWORD_FILE)
                                    .build();
     }
 

--- a/server/src/test/java/io/pravega/schemaregistry/server/rest/ConfigTest.java
+++ b/server/src/test/java/io/pravega/schemaregistry/server/rest/ConfigTest.java
@@ -18,19 +18,25 @@ import static org.junit.Assert.assertTrue;
 
 public class ConfigTest {
     @Test
-    public void testConfig() {
+    public void testValidConfig() {
         ServiceConfig config = ServiceConfig.builder().build();
         assertEquals(config.getHost(), "0.0.0.0");
         assertEquals(config.getPort(), 9092);
         assertFalse(config.isAuthEnabled());
         assertFalse(config.isTlsEnabled());
+    }
 
+    @Test
+    public void testTlsConfig() {
+        // invalid config
         AssertExtensions.assertThrows(IllegalArgumentException.class, () -> ServiceConfig.builder().tlsEnabled(true).build());
         AssertExtensions.assertThrows(IllegalArgumentException.class, () -> ServiceConfig.builder().tlsEnabled(true)
                                                                                          .tlsCertFilePath("a").build());
         AssertExtensions.assertThrows(IllegalArgumentException.class, () -> 
-                ServiceConfig.builder().tlsEnabled(true).tlsCertFilePath("a").serverKeyStoreFilePath("a").build());
-        config = ServiceConfig.builder().tlsEnabled(true).tlsCertFilePath("a").serverKeyStoreFilePath("a").tlsKeyStorePasswordFilePath("a").build();
+                ServiceConfig.builder().tlsEnabled(true).tlsCertFilePath("a").tlsKeyStoreFilePath("a").build());
+        
+        // valid config
+        ServiceConfig config = ServiceConfig.builder().tlsEnabled(true).tlsCertFilePath("a").tlsKeyStoreFilePath("a").tlsKeyStorePasswordFilePath("a").build();
         assertTrue(config.isTlsEnabled());
     }
 }

--- a/server/src/test/java/io/pravega/schemaregistry/server/rest/ConfigTest.java
+++ b/server/src/test/java/io/pravega/schemaregistry/server/rest/ConfigTest.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.schemaregistry.server.rest;
+
+import io.pravega.test.common.AssertExtensions;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class ConfigTest {
+    @Test
+    public void testConfig() {
+        ServiceConfig config = ServiceConfig.builder().build();
+        assertEquals(config.getHost(), "0.0.0.0");
+        assertEquals(config.getPort(), 9092);
+        assertFalse(config.isAuthEnabled());
+        assertFalse(config.isTlsEnabled());
+
+        AssertExtensions.assertThrows(IllegalArgumentException.class, () -> ServiceConfig.builder().tlsEnabled(true).build());
+        AssertExtensions.assertThrows(IllegalArgumentException.class, () -> ServiceConfig.builder().tlsEnabled(true)
+                                                                                         .tlsCertFilePath("a").build());
+        AssertExtensions.assertThrows(IllegalArgumentException.class, () -> 
+                ServiceConfig.builder().tlsEnabled(true).tlsCertFilePath("a").serverKeyStoreFilePath("a").build());
+        config = ServiceConfig.builder().tlsEnabled(true).tlsCertFilePath("a").serverKeyStoreFilePath("a").tlsKeyStorePasswordFilePath("a").build();
+        assertTrue(config.isTlsEnabled());
+    }
+}


### PR DESCRIPTION
**Change log description**  
Fixes bug in ServiceConfig for configuring tls certificate and password file paths

**Purpose of the change**  
Fixes #89 

**What the code does**  
Fixes bug in service config for configuring tls certificate and password file paths

**How to verify it**  
Unit test for service config added. 
