### PR TITLE
Issue 114: AbstractDeserializer should not set positon to arrayOffset

### DIFF
--- a/serializers/shared/src/main/java/io/pravega/schemaregistry/serializer/shared/impl/AbstractDeserializer.java
+++ b/serializers/shared/src/main/java/io/pravega/schemaregistry/serializer/shared/impl/AbstractDeserializer.java
@@ -80,32 +80,32 @@ public abstract class AbstractDeserializer<T> extends BaseDeserializer<T> {
         SchemaInfo writerSchema;
         SchemaInfo readerSchema;
         if (this.encodeHeader) {
-            ByteBuffer decoded;
+            ByteBuffer decodedBytes;
             if (skipHeaders) {
                 data.position(HEADER_SIZE);
-                decoded = data;
+                decodedBytes = data;
                 writerSchema = null;
             } else {
                 byte protocol = data.get();
                 EncodingId encodingId = new EncodingId(data.getInt());
                 EncodingInfo encodingInfo = encodingCache.getGroupEncodingInfo(encodingId);
                 writerSchema = encodingInfo.getSchemaInfo();
-                decoded = decoders.decode(encodingInfo.getCodecType(), data);
+                decodedBytes = decoders.decode(encodingInfo.getCodecType(), data);
             }
 
             byte[] b;
-            if (decoded.hasArray()) {
-                b = decoded.array();
-                start = decoded.arrayOffset() + decoded.position();
+            if (decodedBytes.hasArray()) {
+                b = decodedBytes.array();
+                start = decodedBytes.arrayOffset() + decodedBytes.position();
             } else {
-                b = new byte[decoded.remaining()];
-                decoded.get(b);
-                start = decoded.position();
+                b = new byte[decodedBytes.remaining()];
+                decodedBytes.get(b);
+                start = decodedBytes.position();
             }
 
-            inputStream = new ByteArrayInputStream(b, start, decoded.remaining());
+            inputStream = new ByteArrayInputStream(b, start, decodedBytes.remaining());
             // pass writer schema for schema to be read into
-            readerSchema = schemaInfo == null ? writerSchema : schemaInfo;
+            readerSchema = schemaInfo != null ? schemaInfo : writerSchema;
         } else {
             byte[] b;
             if (data.hasArray()) {

--- a/serializers/shared/src/main/java/io/pravega/schemaregistry/serializer/shared/impl/AbstractDeserializer.java
+++ b/serializers/shared/src/main/java/io/pravega/schemaregistry/serializer/shared/impl/AbstractDeserializer.java
@@ -82,7 +82,7 @@ public abstract class AbstractDeserializer<T> extends BaseDeserializer<T> {
         if (this.encodeHeader) {
             ByteBuffer decoded;
             if (skipHeaders) {
-                data.position(start + HEADER_SIZE);
+                data.position(HEADER_SIZE);
                 decoded = data;
                 writerSchema = null;
             } else {
@@ -93,8 +93,17 @@ public abstract class AbstractDeserializer<T> extends BaseDeserializer<T> {
                 decoded = decoders.decode(encodingInfo.getCodecType(), data);
             }
 
-            inputStream = new ByteArrayInputStream(decoded.array(), 
-                    decoded.arrayOffset() + decoded.position(), decoded.remaining());
+            byte[] b;
+            if (decoded.hasArray()) {
+                b = decoded.array();
+                start = decoded.arrayOffset() + decoded.position();
+            } else {
+                b = new byte[decoded.remaining()];
+                decoded.get(b);
+                start = decoded.position();
+            }
+
+            inputStream = new ByteArrayInputStream(b, start, decoded.remaining());
             // pass writer schema for schema to be read into
             readerSchema = schemaInfo == null ? writerSchema : schemaInfo;
         } else {

--- a/test/src/test/java/io/pravega/schemaregistry/integrationtest/TestPravegaClientEndToEnd.java
+++ b/test/src/test/java/io/pravega/schemaregistry/integrationtest/TestPravegaClientEndToEnd.java
@@ -1422,7 +1422,7 @@ public class TestPravegaClientEndToEnd implements AutoCloseable {
         table.get("k", key1).join();
     }
 
-    class KVSerializer<T extends GeneratedMessageV3> implements Serializer<T> {
+    private static class KVSerializer<T extends GeneratedMessageV3> implements Serializer<T> {
         Serializer<T> serializer;
         Serializer<T> deserializer;
 

--- a/test/src/test/java/io/pravega/schemaregistry/integrationtest/TestPravegaClientEndToEnd.java
+++ b/test/src/test/java/io/pravega/schemaregistry/integrationtest/TestPravegaClientEndToEnd.java
@@ -17,6 +17,8 @@ import com.google.protobuf.DynamicMessage;
 import com.google.protobuf.GeneratedMessageV3;
 import io.pravega.client.ClientConfig;
 import io.pravega.client.EventStreamClientFactory;
+import io.pravega.client.KeyValueTableFactory;
+import io.pravega.client.admin.KeyValueTableManager;
 import io.pravega.client.admin.ReaderGroupManager;
 import io.pravega.client.admin.StreamManager;
 import io.pravega.client.admin.impl.ReaderGroupManagerImpl;
@@ -31,6 +33,9 @@ import io.pravega.client.stream.ReaderGroupConfig;
 import io.pravega.client.stream.ScalingPolicy;
 import io.pravega.client.stream.Serializer;
 import io.pravega.client.stream.StreamConfiguration;
+import io.pravega.client.tables.KeyValueTable;
+import io.pravega.client.tables.KeyValueTableClientConfiguration;
+import io.pravega.client.tables.KeyValueTableConfiguration;
 import io.pravega.common.Exceptions;
 import io.pravega.schemaregistry.client.SchemaRegistryClient;
 import io.pravega.schemaregistry.client.SchemaRegistryClientConfig;
@@ -1369,6 +1374,75 @@ public class TestPravegaClientEndToEnd implements AutoCloseable {
                 EventRead<String> eventRead3 = reader3.readNextEvent(1000L);
                 assertFalse(Strings.isNullOrEmpty(eventRead3.getEvent()));
             }
+        }
+    }
+
+    @Test
+    public void testKeyValue() {
+        String scope = "scope";
+        try (StreamManager streamManager = new StreamManagerImpl(clientConfig)) {
+            streamManager.createScope(scope);
+        }
+        client.addGroup("g1",
+                new GroupProperties(SerializationFormat.Protobuf,
+                        Compatibility.allowAny(),
+                        true));
+
+        KeyValueTableManager tableManager = KeyValueTableManager.create(clientConfig);
+
+        String tableName = "table";
+        tableManager.createKeyValueTable(scope, tableName,
+                KeyValueTableConfiguration.builder().partitionCount(1).build());
+        SerializerConfig serializerConfig = SerializerConfig.builder()
+                                                            .namespace(scope)
+                                                            .groupId(tableName)
+                                                            .createGroup(SerializationFormat.Protobuf,
+                                                                    Compatibility.allowAny(),
+                                                                    true)
+                                                            .registerSchema(true)
+                                                            .registryClient(client)
+                                                            .build();
+        KeyValueTableFactory tableFactory =
+                KeyValueTableFactory.withScope(scope, clientConfig);
+        Serializer<ProtobufTest.Message1> keySerializer = new KVSerializer<>(ProtobufTest.Message1.class, serializerConfig);
+
+        Serializer<ProtobufTest.Message2> valueSerializer = new KVSerializer<>(ProtobufTest.Message2.class, serializerConfig);
+
+        KeyValueTable<ProtobufTest.Message1, ProtobufTest.Message2> table =
+                tableFactory.forKeyValueTable(tableName, keySerializer, valueSerializer,
+                        KeyValueTableClientConfiguration.builder().build());
+
+        ProtobufTest.Message1 key1 = ProtobufTest.Message1.newBuilder().setName("key").build();
+        ProtobufTest.Message2 value1 = ProtobufTest.Message2.newBuilder().setName("value").setField1(0).build();
+        table.put("k", key1, value1).join();
+
+        ProtobufTest.Message1 key2 = ProtobufTest.Message1.newBuilder().setName("test2").build();
+        ProtobufTest.Message2 value2 = ProtobufTest.Message2.newBuilder().setName("test2").setField1(0).build();
+
+        table.get("k", key1).join();
+    }
+
+    class KVSerializer<T extends GeneratedMessageV3> implements Serializer<T> {
+        Serializer<T> serializer;
+        Serializer<T> deserializer;
+
+        // schema registry de/serializers implement one or the other
+        // use a wrapper class to provide to kv table api which needs both
+        KVSerializer(Class<T> clazz, SerializerConfig serializerConfig) {
+            this.serializer = SerializerFactory.protobufSerializer(
+                    serializerConfig, ProtobufSchema.of(clazz));
+            this.deserializer = SerializerFactory.protobufDeserializer(
+                    serializerConfig, ProtobufSchema.of(clazz));
+        }
+
+        @Override
+        public ByteBuffer serialize(T value) {
+            return this.serializer.serialize(value);
+        }
+
+        @Override
+        public T deserialize(ByteBuffer serializedValue) {
+            return this.deserializer.deserialize(serializedValue);
         }
     }
 }


### PR DESCRIPTION
Signed-off-by: Shivesh Ranjan <shivesh.ranjan@gmail.com>

**Change log description**  
Fixes a bug in abstract deserializer where we progress the position by array offset. 

**Purpose of the change**  
Fixes #114 

**What the code does**  
Fixes the bug in abstract deserializer to not use array offset. And also makes sure that the code correctly works when bytebuffer is not backed by array. 

**How to verify it**  
Unit test and integration test added.
