### PR TITLE
Issue119: Better Exception Handling for Unknown Policies when Creating a Group.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -379,6 +379,18 @@ project('serializers') {
         testCompile group: 'ch.qos.logback', name: 'logback-classic', version: qosLogbackVersion
         testCompile group: 'io.pravega', name: 'pravega-test-testcommon', version: pravegaVersion
     }
+    
+    shadowJar {
+        //classifier = 'tests'
+        //from sourceSets.test.output
+        //configurations = [project.configurations.testRuntime]
+        zip64 true
+        relocate 'org.apache.avro', 'io.pravega.schemaregistry.shaded.org.apache.avro'
+        classifier ='all'
+        mergeServiceFiles()
+    }
+    
+    tasks.build.dependsOn tasks.shadowJar
 
     shadowJar {
         zip64 true

--- a/build.gradle
+++ b/build.gradle
@@ -267,7 +267,7 @@ project('serializers:avro') {
         classifier ='all'
         mergeServiceFiles()
     }
-    
+
     tasks.build.dependsOn tasks.shadowJar
     artifacts { archives shadowJar }
     javadoc {
@@ -379,7 +379,7 @@ project('serializers') {
         testCompile group: 'ch.qos.logback', name: 'logback-classic', version: qosLogbackVersion
         testCompile group: 'io.pravega', name: 'pravega-test-testcommon', version: pravegaVersion
     }
-    
+
     shadowJar {
         zip64 true
         relocate 'org.xerial.snappy' , 'io.pravega.schemaregistry.shaded.org.xerial.snappy'
@@ -397,7 +397,7 @@ project('serializers') {
         classifier ='all'
         mergeServiceFiles()
     }
-    
+
     tasks.build.dependsOn tasks.shadowJar
     artifacts { archives shadowJar }
     javadoc {
@@ -493,7 +493,7 @@ project('test') {
         compile project(':common')
         compile project(':contract')
         compile project(':client')
-        compile project(':server') 
+        compile project(':server')
         compile project(':serializers')
         compile project(':serializers:protobuf')
         compile project(':serializers:avro')
@@ -685,4 +685,3 @@ class DockerPushTask extends Exec {
         }
     }
 }
-

--- a/build.gradle
+++ b/build.gradle
@@ -267,7 +267,7 @@ project('serializers:avro') {
         classifier ='all'
         mergeServiceFiles()
     }
-
+    
     tasks.build.dependsOn tasks.shadowJar
     artifacts { archives shadowJar }
     javadoc {
@@ -381,18 +381,6 @@ project('serializers') {
     }
     
     shadowJar {
-        //classifier = 'tests'
-        //from sourceSets.test.output
-        //configurations = [project.configurations.testRuntime]
-        zip64 true
-        relocate 'org.apache.avro', 'io.pravega.schemaregistry.shaded.org.apache.avro'
-        classifier ='all'
-        mergeServiceFiles()
-    }
-    
-    tasks.build.dependsOn tasks.shadowJar
-
-    shadowJar {
         zip64 true
         relocate 'org.xerial.snappy' , 'io.pravega.schemaregistry.shaded.org.xerial.snappy'
         relocate 'org.glassfish.jersey.ext' , 'io.pravega.schemaregistry.shaded.org.glassfish.jersey.ext'
@@ -409,7 +397,7 @@ project('serializers') {
         classifier ='all'
         mergeServiceFiles()
     }
-
+    
     tasks.build.dependsOn tasks.shadowJar
     artifacts { archives shadowJar }
     javadoc {
@@ -505,7 +493,7 @@ project('test') {
         compile project(':common')
         compile project(':contract')
         compile project(':client')
-        compile project(':server')
+        compile project(':server') 
         compile project(':serializers')
         compile project(':serializers:protobuf')
         compile project(':serializers:avro')
@@ -697,3 +685,4 @@ class DockerPushTask extends Exec {
         }
     }
 }
+

--- a/contract/src/main/java/io/pravega/schemaregistry/contract/transform/ModelHelper.java
+++ b/contract/src/main/java/io/pravega/schemaregistry/contract/transform/ModelHelper.java
@@ -75,8 +75,9 @@ public class ModelHelper {
 
     public static io.pravega.schemaregistry.contract.data.Compatibility decode(Compatibility compatibility) {
         io.pravega.schemaregistry.contract.data.Compatibility decoded;
-        if(compatibility.getPolicy() == null)
+        if (compatibility.getPolicy() == null) {
             throw new IllegalArgumentException("Unknown compatibility type");
+        }
         switch (compatibility.getPolicy()) {
             case ALLOWANY:
                 decoded = io.pravega.schemaregistry.contract.data.Compatibility.allowAny();

--- a/contract/src/main/java/io/pravega/schemaregistry/contract/transform/ModelHelper.java
+++ b/contract/src/main/java/io/pravega/schemaregistry/contract/transform/ModelHelper.java
@@ -75,6 +75,8 @@ public class ModelHelper {
 
     public static io.pravega.schemaregistry.contract.data.Compatibility decode(Compatibility compatibility) {
         io.pravega.schemaregistry.contract.data.Compatibility decoded;
+        if(compatibility.getPolicy() == null)
+            throw new IllegalArgumentException("Unknown compatibility type");
         switch (compatibility.getPolicy()) {
             case ALLOWANY:
                 decoded = io.pravega.schemaregistry.contract.data.Compatibility.allowAny();

--- a/contract/src/test/java/io/pravega/schemaregistry/contract/transform/ModelHelperTest.java
+++ b/contract/src/test/java/io/pravega/schemaregistry/contract/transform/ModelHelperTest.java
@@ -235,7 +235,6 @@ public class ModelHelperTest {
         encoded = convert(ModelHelper.encode(compatibility), Compatibility.class);
         decoded = ModelHelper.decode(encoded);
         assertEquals(compatibility, decoded);
-        
     }
     
     private <T> T convert(T t, Class<T> tClass) throws IOException {

--- a/contract/src/test/java/io/pravega/schemaregistry/contract/transform/ModelHelperTest.java
+++ b/contract/src/test/java/io/pravega/schemaregistry/contract/transform/ModelHelperTest.java
@@ -27,6 +27,7 @@ import io.pravega.schemaregistry.contract.generated.rest.model.SchemaInfo;
 import io.pravega.schemaregistry.contract.generated.rest.model.SchemaWithVersion;
 import io.pravega.schemaregistry.contract.generated.rest.model.SerializationFormat;
 import io.pravega.schemaregistry.contract.generated.rest.model.VersionInfo;
+import io.pravega.test.common.AssertExtensions;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -97,6 +98,10 @@ public class ModelHelperTest {
 
         io.pravega.schemaregistry.contract.data.EncodingId encodingId = ModelHelper.decode(new EncodingId().encodingId(1));
         assertEquals(encodingId.getId(), 1);
+        
+        // to test the exception thrown for incorrect policy input
+        Compatibility compatibility1 = new Compatibility().policy(Compatibility.PolicyEnum.fromValue("None"));
+        AssertExtensions.assertThrows("An error should have been thrown", () -> ModelHelper.decode(compatibility1), e -> e instanceof IllegalArgumentException);
     }
 
     @Test
@@ -230,6 +235,7 @@ public class ModelHelperTest {
         encoded = convert(ModelHelper.encode(compatibility), Compatibility.class);
         decoded = ModelHelper.decode(encoded);
         assertEquals(compatibility, decoded);
+        
     }
     
     private <T> T convert(T t, Class<T> tClass) throws IOException {

--- a/server/src/test/java/io/pravega/schemaregistry/server/rest/resources/SchemaRegistryResourceTest.java
+++ b/server/src/test/java/io/pravega/schemaregistry/server/rest/resources/SchemaRegistryResourceTest.java
@@ -147,6 +147,13 @@ public class SchemaRegistryResourceTest extends JerseyTest {
         response = target(GROUPS).request().async().post(
                 Entity.entity(createGroupRequest, MediaType.APPLICATION_JSON)).get();
         assertEquals(409, response.getStatus());
+        //IllegalArgumentException
+        doAnswer(x ->
+                Futures.failedFuture(new IllegalArgumentException())
+        ).when(service).createGroup(any(), anyString(), any());
+        response = target(GROUPS).request().async().post(
+                Entity.entity(createGroupRequest, MediaType.APPLICATION_JSON)).get();
+        assertEquals(400, response.getStatus());
         // Runtime Exception
         doAnswer(x ->
                 Futures.failedFuture(new RuntimeException())


### PR DESCRIPTION
**Change log description**  
Adds a null check to throw appropriate exception when unknown policy is used to create a group.

**Purpose of the change**  
Fixes #119 

**What the code does**  
An if statement is added before the switch statement of the overloaded decode method (for Compatibility) in the ModelHelper class. The if statement checks to see if `compatibility.getPolicy()` is null and if so, throws an Illegal Argument exception with the message  `Unknown Compatibility Type`.

**How to verify it**  
Create a group with unknown compatibility policy. 
