### PR TITLE
Issue 126: Change master version to 0.2 snapshot

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -51,7 +51,7 @@ pravegaVersion=0.8.0-2623.279ac21-SNAPSHOT
 pravegaKeyCloakVersion=0.7.0
 
 # Version and base tags can be overridden at build time
-schemaregistryVersion=0.1.0-SNAPSHOT
+schemaregistryVersion=0.2.0-SNAPSHOT
 schemaregistryBaseTag=pravega/schemaregistry
 
 # Pravega Signing Key


### PR DESCRIPTION
Signed-off-by: Shivesh Ranjan <shivesh.ranjan@gmail.com>

**Change log description**  
Change master version to 0.2 snapshot in gradle.properties

**Purpose of the change**  
Fixes #126 

**What the code does**  
Change master version to 0.2 snapshot in gradle.properties

**How to verify it**  
All tests should pass
