### PR TITLE
Issue 130: Change project's groupId

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -252,7 +252,6 @@ project('serializers:avro') {
     shadowJar {
         // Add zip64=true so that we are able to pack more than 65k files in the jar.
         zip64 true
-        relocate 'org.apache.avro', 'io.pravega.schemaregistry.shaded.org.apache.avro'
         relocate 'org.xerial.snappy' , 'io.pravega.schemaregistry.shaded.org.xerial.snappy'
         relocate 'org.glassfish.jersey.ext' , 'io.pravega.schemaregistry.shaded.org.glassfish.jersey.ext'
         relocate 'org.glassfish.jersey.core' , 'io.pravega.schemaregistry.shaded.org.glassfish.jersey.core'
@@ -295,7 +294,6 @@ project('serializers:protobuf') {
 
     shadowJar {
         zip64 true
-        relocate 'com.google.protobuf' , 'io.pravega.schemaregistry.shaded.com.google.protobuf'
         relocate 'org.xerial.snappy' , 'io.pravega.schemaregistry.shaded.org.xerial.snappy'
         relocate 'org.glassfish.jersey.ext' , 'io.pravega.schemaregistry.shaded.org.glassfish.jersey.ext'
         relocate 'org.glassfish.jersey.core' , 'io.pravega.schemaregistry.shaded.org.glassfish.jersey.core'
@@ -338,8 +336,6 @@ project('serializers:json') {
 
     shadowJar {
         zip64 true
-        relocate 'com.github.everit-org.json-schema' , 'io.pravega.schemaregistry.shaded.com.github.everit-org.json-schema'
-        relocate 'com.fasterxml.jackson.module' , 'io.pravega.schemaregistry.shaded.com.fasterxml.jackson.module'
         relocate 'org.xerial.snappy' , 'io.pravega.schemaregistry.shaded.org.xerial.snappy'
         relocate 'org.glassfish.jersey.ext' , 'io.pravega.schemaregistry.shaded.org.glassfish.jersey.ext'
         relocate 'org.glassfish.jersey.core' , 'io.pravega.schemaregistry.shaded.org.glassfish.jersey.core'
@@ -386,10 +382,6 @@ project('serializers') {
     
     shadowJar {
         zip64 true
-        relocate 'com.google.protobuf' , 'io.pravega.schemaregistry.shaded.com.google.protobuf'
-        relocate 'org.apache.avro', 'io.pravega.schemaregistry.shaded.org.apache.avro'
-        relocate 'com.github.everit-org.json-schema' , 'io.pravega.schemaregistry.shaded.com.github.everit-org.json-schema'
-        relocate 'com.fasterxml.jackson.module' , 'io.pravega.schemaregistry.shaded.com.fasterxml.jackson.module'
         relocate 'org.xerial.snappy' , 'io.pravega.schemaregistry.shaded.org.xerial.snappy'
         relocate 'org.glassfish.jersey.ext' , 'io.pravega.schemaregistry.shaded.org.glassfish.jersey.ext'
         relocate 'org.glassfish.jersey.core' , 'io.pravega.schemaregistry.shaded.org.glassfish.jersey.core'

--- a/build.gradle
+++ b/build.gradle
@@ -106,7 +106,7 @@ allprojects {
         }
     }
     version = getProjectVersion()
-    group = "io.pravega.schemaregistry"
+    group = "io.pravega"
 
     configurations.all {
         resolutionStrategy {

--- a/gradle/maven.gradle
+++ b/gradle/maven.gradle
@@ -83,7 +83,7 @@ plugins.withId('maven') {
     install {
         repositories {
             mavenInstaller {
-                pom.artifactId = project.path.replaceFirst(':', '').replace(':', '-')
+                pom.artifactId = 'schemaregistry-' + project.path.replaceFirst(':', '').replace(':', '-')
             }
         }
     }

--- a/gradle/maven.gradle
+++ b/gradle/maven.gradle
@@ -15,7 +15,7 @@ plugins.withId('maven') {
                 // Only configure publishing if a URL was provided
                 if (project.hasProperty("publishUrl")) {
                     if (publishUrl == "mavenCentral") {
-                        repository(url: "https://oss.sonatype.org/io.pravega.service/local/staging/deploy/maven2/") {
+                        repository(url: "https://oss.sonatype.org/service/local/staging/deploy/maven2/") {
                             authentication(userName: publishUsername, password: publishPassword)
                         }
                         snapshotRepository(url: "https://oss.sonatype.org/content/repositories/snapshots/") {
@@ -42,7 +42,7 @@ plugins.withId('maven') {
                     }
                 }
 
-                pom.artifactId = project.path.replaceFirst(':', '').replace(':', '-')
+                pom.artifactId = 'schemaregistry-' + project.path.replaceFirst(':', '').replace(':', '-')
                 pom.project {
                     name "Pravega"
                     url "http://pravega.io"


### PR DESCRIPTION
Signed-off-by: Shivesh Ranjan <shivesh.ranjan@gmail.com>

**Change log description**  
 Change groupId from io.pravega.schemaregistry to io.pravega so that it shows up in the same group in maven.

**Purpose of the change**  
Fixes #130 

**What the code does**  
 Changes groupId from io.pravega.schemaregistry to io.pravega in build.gradle
Also adds schemaregistry prefix on all artifacts produced by schema registry

**How to verify it**  
Artifacts should be produced with group id io.pravega and artifacts should have schemaregistry prefix
