### PR TITLE
Issue 134: Change pravega version to 0.8.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -47,7 +47,7 @@ gradleGitPluginVersion=2.2.0
 avroVersion=1.9.1
 avroProtobufVersion=1.7.7
 snappyVersion=1.1.7.3
-pravegaVersion=0.8.0-2623.279ac21-SNAPSHOT
+pravegaVersion=0.8.0
 pravegaKeyCloakVersion=0.7.0
 
 # Version and base tags can be overridden at build time

--- a/gradle.properties
+++ b/gradle.properties
@@ -48,7 +48,7 @@ avroVersion=1.9.1
 avroProtobufVersion=1.7.7
 snappyVersion=1.1.7.3
 pravegaVersion=0.8.0
-pravegaKeyCloakVersion=0.7.0
+pravegaKeyCloakVersion=0.8.0
 
 # Version and base tags can be overridden at build time
 schemaregistryVersion=0.1.0

--- a/gradle/java.gradle
+++ b/gradle/java.gradle
@@ -29,7 +29,7 @@ plugins.withId('java') {
         ])
     }
 
-    archivesBaseName = "pravega" + project.path.replace(':', '-')
+    archivesBaseName = "schemaregistry" + project.path.replace(':', '-')
 
     task sourceJar(type: Jar) {
         classifier = 'sources'


### PR DESCRIPTION
Signed-off-by: Shivesh Ranjan <shivesh.ranjan@gmail.com>

**Change log description**  
Changes pravega version to 0.8.0 in gradle.properties.

**Purpose of the change**  
Fixes #134 

**What the code does**  
Changes pravega version to 0.8.0 in gradle.properties.
Also changes the compiled jar name's prefix from pravega to schemaregistry. 

**How to verify it**  
All tests should pass