### PR TITLE
Issue 137: Change version to 0.1.1-SNAPSHOT in r0.1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -51,7 +51,7 @@ pravegaVersion=0.8.0
 pravegaKeyCloakVersion=0.8.0
 
 # Version and base tags can be overridden at build time
-schemaregistryVersion=0.1.0
+schemaregistryVersion=0.1.1-SNAPSHOT
 schemaregistryBaseTag=pravega/schemaregistry
 
 # Pravega Signing Key


### PR DESCRIPTION
Signed-off-by: Shivesh Ranjan <shivesh.ranjan@gmail.com>

**Change log description**  
Change version to 0.1.1-SNAPSHOT in r0.1

**Purpose of the change**  
Fixes #137 

**What the code does**  
in gradle.properties it changes version to 0.1.1-SNAPSHOT in r0.1

**How to verify it**  
All tests should pass.