### PR TITLE
[fixed] Issue 140 Move creation of DatumWriters(thread safe) in AvroS…

### DIFF
--- a/serializers/avro/src/main/java/io/pravega/schemaregistry/serializer/avro/impl/AvroSerializer.java
+++ b/serializers/avro/src/main/java/io/pravega/schemaregistry/serializer/avro/impl/AvroSerializer.java
@@ -27,30 +27,30 @@ import java.io.IOException;
 import java.io.OutputStream;
 
 public class AvroSerializer<T> extends AbstractSerializer<T> {
-    private final AvroSchema<T> avroSchema;
+
+    private final SpecificDatumWriter<T> specificDatumWriter;
+    private final GenericDatumWriter<T> genericDatumWriter;
+    private final ReflectDatumWriter<T> reflectDatumWriter;
+
     public AvroSerializer(String groupId, SchemaRegistryClient client, AvroSchema<T> schema,
-                   Encoder encoder, boolean registerSchema) {
+                          Encoder encoder, boolean registerSchema) {
         super(groupId, client, schema, encoder, registerSchema, true);
-        this.avroSchema = schema;
+        Schema avroSchema = schema.getSchema();
+        this.specificDatumWriter = new SpecificDatumWriter<>(avroSchema);
+        this.genericDatumWriter = new GenericDatumWriter<>(avroSchema);
+        this.reflectDatumWriter = new ReflectDatumWriter<>(avroSchema);
     }
 
     @Override
     protected void serialize(T var, SchemaInfo schemaInfo, OutputStream outputStream) throws IOException {
-        Schema schema = avroSchema.getSchema();
-        
         BinaryEncoder encoder = EncoderFactory.get().binaryEncoder(outputStream, null);
 
-        if (IndexedRecord.class.isAssignableFrom(var.getClass())) {
-            if (SpecificRecord.class.isAssignableFrom(var.getClass())) {
-                SpecificDatumWriter<T> writer = new SpecificDatumWriter<>(schema);
-                writer.write(var, encoder);
-            } else {
-                GenericDatumWriter<T> writer = new GenericDatumWriter<>(schema);
-                writer.write(var, encoder);
-            }
+        if (SpecificRecord.class.isAssignableFrom(var.getClass())) {
+            specificDatumWriter.write(var, encoder);
+        } else if (IndexedRecord.class.isAssignableFrom(var.getClass())) {
+            genericDatumWriter.write(var, encoder);
         } else {
-            ReflectDatumWriter<T> writer = new ReflectDatumWriter<>(schema);
-            writer.write(var, encoder);
+            reflectDatumWriter.write(var, encoder);
         }
 
         encoder.flush();


### PR DESCRIPTION
Move creation of DatumWriters (thread safe) in AvroSerializer class to constructor
Replace of  https://github.com/pravega/schema-registry/pull/141 

Change log description
Move creation of DatumWriters (thread safe) in AvroSerializer class to constructor 

Purpose of the change
Fixes #140 

What the code does
Move creation of DatumWriters (thread safe) in AvroSerializer class to constructor. 

How to verify it
All tests should pass
