### PR TITLE
Issue 156: Make pravega client compileOnly dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -572,6 +572,34 @@ distributions {
             from 'NOTICE'
         }
     }
+    avroserializer {
+        baseName = "schema-registry-avro-serializer"
+        contents {
+            from { project(":serializers:avro").configurations.runtime }
+            from { project(":serializers:avro").configurations.runtime.allArtifacts.files }
+            from 'LICENSE'
+            from 'NOTICE'
+        }
+    }
+    protobufserializer {
+        baseName = "schema-registry-protobuf-serializer"
+        contents {
+            from { project(":serializers:protobuf").configurations.runtime }
+            from { project(":serializers:protobuf").configurations.runtime.allArtifacts.files }
+            from 'LICENSE'
+            from 'NOTICE'
+        }
+    }
+    jsonserializer {
+        baseName = "schema-registry-json-serializer"
+        contents {
+            from { project(":serializers:json").configurations.runtime }
+            from { project(":serializers:json").configurations.runtime.allArtifacts.files }
+            from 'LICENSE'
+            from 'NOTICE'
+        }
+    }
+
 }
 
 task sourceCopy(type: Copy) {
@@ -649,6 +677,10 @@ task pushRegistryImage(type: DockerPushTask) {
 
 task dockerPush(dependsOn: pushRegistryImage) {
     description = "Push all docker images"
+}
+
+task distribution(dependsOn: [assembleDist, assembleClientDist, assembleSerializersDist, assembleAvroserializerDist, assembleProtobufserializerDist, assembleJsonserializerDist]) {
+    description = "Builds a distribution package"
 }
 
 /**

--- a/build.gradle
+++ b/build.gradle
@@ -145,7 +145,6 @@ project('auth') {
     dependencies {
         compile project(':common')
         compile group: 'io.pravega', name: 'pravega-shared-authplugin', version: pravegaVersion
-        compile group: 'io.pravega', name: 'pravega-keycloak-client', version: pravegaKeyCloakVersion
     }
 
     javadoc {
@@ -221,11 +220,12 @@ project('serializers:shared') {
     dependencies {
         compile project(':common')
         compile project(':client')
-        compile group: 'io.pravega', name: 'pravega-client', version: pravegaVersion
+        compileOnly group: 'io.pravega', name: 'pravega-client', version: pravegaVersion
         compile group: 'org.xerial.snappy', name: 'snappy-java', version: snappyVersion
         testCompile group: 'org.slf4j', name: 'log4j-over-slf4j', version: slf4jApiVersion
         testCompile group: 'ch.qos.logback', name: 'logback-classic', version: qosLogbackVersion
         testCompile group: 'io.pravega', name: 'pravega-test-testcommon', version: pravegaVersion
+        testCompile group: 'io.pravega', name: 'pravega-client', version: pravegaVersion
     }
 
     javadoc {
@@ -243,10 +243,13 @@ project('serializers:avro') {
     dependencies {
         compile project(':serializers:shared')
         compile group: 'org.apache.avro', name: 'avro', version: avroVersion
+        compileOnly group: 'io.pravega', name: 'pravega-client', version: pravegaVersion
+
         testCompile project(path:':serializers:shared', configuration:'testRuntime')
         testCompile group: 'org.slf4j', name: 'log4j-over-slf4j', version: slf4jApiVersion
         testCompile group: 'ch.qos.logback', name: 'logback-classic', version: qosLogbackVersion
         testCompile group: 'io.pravega', name: 'pravega-test-testcommon', version: pravegaVersion
+        testCompile group: 'io.pravega', name: 'pravega-client', version: pravegaVersion
     }
 
     shadowJar {
@@ -286,10 +289,13 @@ project('serializers:protobuf') {
         compile project(':serializers:shared')
         compile group: 'com.google.protobuf', name: 'protobuf-java', version: protobufProtocVersion
         compile group: 'com.google.protobuf', name: 'protobuf-java-util', version: protobufUtilVersion
+        compileOnly group: 'io.pravega', name: 'pravega-client', version: pravegaVersion
+
         testCompile project(path:':serializers:shared', configuration:'testRuntime')
         testCompile group: 'org.slf4j', name: 'log4j-over-slf4j', version: slf4jApiVersion
         testCompile group: 'ch.qos.logback', name: 'logback-classic', version: qosLogbackVersion
         testCompile group: 'io.pravega', name: 'pravega-test-testcommon', version: pravegaVersion
+        testCompile group: 'io.pravega', name: 'pravega-client', version: pravegaVersion
     }
 
     shadowJar {
@@ -328,10 +334,13 @@ project('serializers:json') {
         compile project(':serializers:shared')
         compile group: 'com.github.everit-org.json-schema', name: 'org.everit.json.schema', version: everitVersion
         compile group: 'com.fasterxml.jackson.module', name: 'jackson-module-jsonSchema', version: jacksonVersion
+        compileOnly group: 'io.pravega', name: 'pravega-client', version: pravegaVersion
+
         testCompile project(path:':serializers:shared', configuration:'testRuntime')
         testCompile group: 'org.slf4j', name: 'log4j-over-slf4j', version: slf4jApiVersion
         testCompile group: 'ch.qos.logback', name: 'logback-classic', version: qosLogbackVersion
         testCompile group: 'io.pravega', name: 'pravega-test-testcommon', version: pravegaVersion
+        testCompile group: 'io.pravega', name: 'pravega-client', version: pravegaVersion
     }
 
     shadowJar {
@@ -371,6 +380,8 @@ project('serializers') {
         compile project(':serializers:protobuf')
         compile project(':serializers:json')
         compile group: 'org.xerial.snappy', name: 'snappy-java', version: snappyVersion
+        compileOnly group: 'io.pravega', name: 'pravega-client', version: pravegaVersion
+
         testCompile project(path:':serializers:shared', configuration:'testRuntime')
         testCompile files(project(':serializers:avro').sourceSets.test.output)
         testCompile files(project(':serializers:protobuf').sourceSets.test.output)
@@ -378,6 +389,7 @@ project('serializers') {
         testCompile group: 'org.slf4j', name: 'log4j-over-slf4j', version: slf4jApiVersion
         testCompile group: 'ch.qos.logback', name: 'logback-classic', version: qosLogbackVersion
         testCompile group: 'io.pravega', name: 'pravega-test-testcommon', version: pravegaVersion
+        testCompile group: 'io.pravega', name: 'pravega-client', version: pravegaVersion
     }
     
     shadowJar {
@@ -459,6 +471,8 @@ project('server') {
         compile group: 'com.google.protobuf', name: 'protobuf-java', version: protobufProtocVersion
         compile group: 'com.fasterxml.jackson.module', name: 'jackson-module-jsonSchema', version: jacksonVersion
         compile group: 'com.github.everit-org.json-schema', name: 'org.everit.json.schema', version: everitVersion
+        runtime group: 'io.pravega', name: 'pravega-keycloak-client', version: pravegaKeyCloakVersion
+
         testCompile (group: 'io.pravega', name: 'pravega-standalone', version: pravegaVersion) {
             exclude group: 'javax.ws.rs', module: 'jsr311-api'
         }
@@ -499,6 +513,8 @@ project('test') {
         compile project(':serializers:avro')
         compile project(':serializers:json')
         compile project(':serializers:shared')
+        compile group: 'io.pravega', name: 'pravega-client', version: pravegaVersion
+
         testCompile (group: 'io.pravega', name: 'pravega-standalone', version: pravegaVersion) {
             exclude group: 'javax.ws.rs', module: 'jsr311-api'
         }


### PR DESCRIPTION
Signed-off-by: Shivesh Ranjan <shivesh.ranjan@gmail.com>

**Change log description**  
Makes pravega client compileonly dependency

**Purpose of the change**  
Fixes #156 

**What the code does**  
Updates build.gradle to make pravega client compile only dependency. 
Schema registry serializers depend on pravega Serializer interface which they provide an implementation for. So they take a dependency on pravega client for it.
For `Serializers` we have a "serializers:shared" project which earlier had compile dependency on pravega-client and serializers:avro etc took dependency on serializers:shared.
now we make pravega client dependency `compile only` so we dont bundle pravega client with schema registry serializers.
so this is changed in `serializers:shared` and since pravega client is only compileonly dependency in serializers:shared, we have to make it compile only dependency in projects that depended on serializers:shared. So the same change is made in protobuf, avro, json.

Apart from the above, we also moved dependency on the pravega keycloak client from auth to schema registry server. 

Another change we have made as part of this PR is to add "distribution" task for serializers. 

**How to verify it**  
Build should pass