### PR TITLE
Passthrough labels and annotations for the service.

### DIFF
--- a/charts/schema-registry/templates/service.yaml
+++ b/charts/schema-registry/templates/service.yaml
@@ -8,6 +8,7 @@
 #  *     http://www.apache.org/licenses/LICENSE-2.0
 #  */
 
+{{ $svc := .Values.service }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -15,6 +16,11 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
 {{ include "schema-registry.commonLabels" . | indent 4 }}
+{{- if $svc.labels }}
+{{ toYaml $svc.labels | indent 4 }}
+{{- end }}
+  annotations:
+{{ toYaml $svc.annotations | indent 4 }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/charts/schema-registry/values.yaml
+++ b/charts/schema-registry/values.yaml
@@ -28,6 +28,8 @@ serviceAccount:
 service:
   type: LoadBalancer
   port: 9092
+  annotations: {}
+  labels: {}
 
 initContainer: {}
   # name: ""


### PR DESCRIPTION
**Purpose of the change**  

Being able to pass annotations or labels for the service that schema registry deploys is useful. Easier to manager and track it with other components deployed on a K8s cluster this way (based on putting some annotations on the service).

**How to verify it**  

It is pretty minute code change.

You can test it out with various values files like this:

```
helm install schema charts/schema-registry --debug --dry-run -f values.yaml
```
