### PR TITLE
Issue 152: Disable basic auth was not enforced

### DIFF
--- a/server/src/main/java/io/pravega/schemaregistry/server/rest/ServiceConfig.java
+++ b/server/src/main/java/io/pravega/schemaregistry/server/rest/ServiceConfig.java
@@ -33,10 +33,13 @@ public class ServiceConfig implements ServerConfig {
     private final String tlsKeyStorePasswordFilePath;
     private final boolean authEnabled;
     @ToString.Exclude
+    private final boolean disablePasswordAuth;
+    @ToString.Exclude
     private final String userPasswordFilePath;
 
     private ServiceConfig(String host, int port, boolean tlsEnabled, String tlsCertFilePath, 
-                          String tlsKeyStoreFilePath, String tlsKeyStorePasswordFilePath, boolean authEnabled, String userPasswordFilePath) {
+                          String tlsKeyStoreFilePath, String tlsKeyStorePasswordFilePath, boolean authEnabled, 
+                          boolean disablePasswordAuth, String userPasswordFilePath) {
         Exceptions.checkNotNullOrEmpty(host, "host");
         Exceptions.checkArgument(port > 0, "port", "Should be positive integer");
         if (tlsEnabled) {
@@ -54,6 +57,7 @@ public class ServiceConfig implements ServerConfig {
         this.tlsKeyStoreFilePath = tlsKeyStoreFilePath;
         this.tlsKeyStorePasswordFilePath = tlsKeyStorePasswordFilePath;
         this.authEnabled = authEnabled;
+        this.disablePasswordAuth = disablePasswordAuth;
         this.userPasswordFilePath = userPasswordFilePath;
     }
 
@@ -62,5 +66,6 @@ public class ServiceConfig implements ServerConfig {
         private int port = 9092;
         private boolean tlsEnabled = false;
         private boolean authEnabled = false;
+        private boolean disablePasswordAuth = false;
     }
 }

--- a/server/src/main/java/io/pravega/schemaregistry/server/rest/auth/AuthHandlerManager.java
+++ b/server/src/main/java/io/pravega/schemaregistry/server/rest/auth/AuthHandlerManager.java
@@ -11,6 +11,7 @@ package io.pravega.schemaregistry.server.rest.auth;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
+import io.pravega.auth.AuthConstants;
 import io.pravega.auth.AuthHandler;
 import io.pravega.auth.AuthenticationException;
 import io.pravega.controller.server.security.auth.handler.impl.PasswordAuthHandler;
@@ -18,6 +19,8 @@ import io.pravega.schemaregistry.server.rest.ServiceConfig;
 import lombok.extern.slf4j.Slf4j;
 
 import javax.ws.rs.core.SecurityContext;
+import java.util.Collections;
+import java.util.Map;
 import java.util.ServiceLoader;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -29,6 +32,7 @@ import static io.pravega.schemaregistry.common.AuthHelper.extractMethodAndToken;
 @Slf4j
 public class AuthHandlerManager {
     private final ServiceConfig serverConfig;
+    
     private final ConcurrentHashMap<String, AuthHandler> handlerMap;
 
     public AuthHandlerManager(ServiceConfig serverConfig) {
@@ -42,6 +46,9 @@ public class AuthHandlerManager {
             if (serverConfig.isAuthEnabled()) {
                 ServiceLoader<AuthHandler> loader = ServiceLoader.load(AuthHandler.class);
                 for (AuthHandler handler : loader) {
+                    if (serverConfig.isDisablePasswordAuth() && handler.getHandlerName().equals(AuthConstants.BASIC)) {
+                        continue;
+                    }
                     if (handler instanceof PasswordAuthHandler && !(handler instanceof BasicAuthHandler)) {
                         continue;
                     }
@@ -113,5 +120,14 @@ public class AuthHandlerManager {
     void registerHandler(AuthHandler authHandler) {
         Preconditions.checkNotNull(authHandler, "authHandler");
         this.handlerMap.put(authHandler.getHandlerName(), authHandler);
+    }
+
+    /**
+     * This method is not only visible for testing, but also intended to be used solely for testing. 
+     * This returns the handler map to the test for verification.
+     */
+    @VisibleForTesting
+    Map<String, AuthHandler> getHandlerMap() {
+        return Collections.unmodifiableMap(handlerMap);
     }
 }

--- a/server/src/main/java/io/pravega/schemaregistry/server/rest/auth/AuthHandlerManager.java
+++ b/server/src/main/java/io/pravega/schemaregistry/server/rest/auth/AuthHandlerManager.java
@@ -55,7 +55,7 @@ public class AuthHandlerManager {
                     try {
                         handler.initialize(serverConfig);
                         registerHandler(handler);
-                    } catch (Exception e) {
+                    } catch (Throwable e) {
                         log.warn("Exception while initializing auth handler {}", handler, e);
                     }
                 }

--- a/server/src/main/java/io/pravega/schemaregistry/service/Config.java
+++ b/server/src/main/java/io/pravega/schemaregistry/service/Config.java
@@ -226,6 +226,7 @@ public final class Config {
                                    .tlsCertFilePath(Config.TLS_CERT_FILE)
                                    .tlsKeyStoreFilePath(Config.TLS_KEY_FILE)
                                    .tlsKeyStorePasswordFilePath(Config.TLS_KEY_PASSWORD_FILE)
+                                   .disablePasswordAuth(Config.DISABLE_BASIC_AUTHENTICATION)
                                    .build();
     }
 

--- a/server/src/test/java/io/pravega/schemaregistry/server/rest/auth/AuthHandlerManagerTest.java
+++ b/server/src/test/java/io/pravega/schemaregistry/server/rest/auth/AuthHandlerManagerTest.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.schemaregistry.server.rest.auth;
+
+import io.pravega.auth.AuthConstants;
+import io.pravega.controller.server.security.auth.StrongPasswordProcessor;
+import io.pravega.schemaregistry.server.rest.ServiceConfig;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.security.NoSuchAlgorithmException;
+import java.security.spec.InvalidKeySpecException;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+
+public class AuthHandlerManagerTest {
+    @Test
+    public void testDisableBasicAuth() {
+        ServiceConfig serviceConfig = ServiceConfig.builder()
+                                                   .authEnabled(true)
+                                                   .userPasswordFilePath(createAuthFile().getAbsolutePath())
+                                                   .build();
+        AuthHandlerManager manager = new AuthHandlerManager(serviceConfig);
+
+        assertTrue(manager.getHandlerMap().containsKey(AuthConstants.BASIC));
+        serviceConfig = ServiceConfig.builder().authEnabled(true).disablePasswordAuth(true)
+                                                   .build();
+        manager = new AuthHandlerManager(serviceConfig);
+        assertFalse(manager.getHandlerMap().containsKey(AuthConstants.BASIC));
+    }
+
+    private File createAuthFile() {
+        try {
+            File authFile = File.createTempFile("auth_file", ".txt");
+            StrongPasswordProcessor passwordEncryptor = StrongPasswordProcessor.builder().build();
+
+            try (FileWriter writer = new FileWriter(authFile.getAbsolutePath())) {
+                String defaultPassword = passwordEncryptor.encryptPassword("password");
+                writer.write(String.format("%s:%s:%s%n", "admin", defaultPassword, "prn::*,READ_UPDATE;"));
+            }
+            return authFile;
+        } catch (IOException | NoSuchAlgorithmException | InvalidKeySpecException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}


### PR DESCRIPTION
Signed-off-by: Shivesh Ranjan <shivesh.ranjan@gmail.com>

**Change log description**  
Fixes issue in disable basic auth flag which was not enforced in auth handler manager. 

**Purpose of the change**  
Fixes #152 

**What the code does**  
Adds a new config value in ServiceConfig for disabling basic auth. Enforces that policy in AuthHandlerManager while loading auth handlers. 

**How to verify it**  
Unit test added. 