### PR TITLE
Issue 168: Get namespace api on SchemaRegistryClient

### DIFF
--- a/client/src/main/java/io/pravega/schemaregistry/client/SchemaRegistryClient.java
+++ b/client/src/main/java/io/pravega/schemaregistry/client/SchemaRegistryClient.java
@@ -346,4 +346,11 @@ public interface SchemaRegistryClient extends AutoCloseable {
      * @throws UnauthorizedException if the user is unauthorized.
      */
     Map<String, VersionInfo> getSchemaReferences(SchemaInfo schemaInfo) throws ResourceNotFoundException, UnauthorizedException;
+
+    /**
+     * The Namespace which is used for making all client requests to registry service. 
+     * 
+     * @return Namespace used for the client. 
+     */
+    String getNamespace();
 }

--- a/client/src/main/java/io/pravega/schemaregistry/client/SchemaRegistryClientImpl.java
+++ b/client/src/main/java/io/pravega/schemaregistry/client/SchemaRegistryClientImpl.java
@@ -35,6 +35,7 @@ import io.pravega.schemaregistry.contract.generated.rest.model.Valid;
 import io.pravega.schemaregistry.contract.generated.rest.model.ValidateRequest;
 import io.pravega.schemaregistry.contract.transform.ModelHelper;
 import io.pravega.schemaregistry.contract.v1.ApiV1;
+import lombok.Getter;
 import lombok.SneakyThrows;
 import org.glassfish.jersey.client.ClientConfig;
 import org.glassfish.jersey.client.proxy.WebResourceFactory;
@@ -83,6 +84,7 @@ public class SchemaRegistryClientImpl implements SchemaRegistryClient {
 
     private final ApiV1.GroupsApi groupProxy;
     private final ApiV1.SchemasApi schemaProxy;
+    @Getter
     private final String namespace;
     private final Client client;
     

--- a/client/src/test/java/io/pravega/schemaregistry/client/SchemaRegistryClientTest.java
+++ b/client/src/test/java/io/pravega/schemaregistry/client/SchemaRegistryClientTest.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.schemaregistry.client;
+
+import java.net.URI;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+public class SchemaRegistryClientTest {
+    @Test
+    public void testClientFactory() throws Exception {
+        URI schemaRegistryUri = URI.create("http://localhost:9092");
+        SchemaRegistryClientConfig config = SchemaRegistryClientConfig.builder()
+                                                                      .schemaRegistryUri(schemaRegistryUri)
+                                                                      .build();
+
+        SchemaRegistryClient client = SchemaRegistryClientFactory.withDefaultNamespace(config);
+        assertNull(client.getNamespace());
+        client.close();
+        client = SchemaRegistryClientFactory.withNamespace("a", config);
+
+        assertEquals("a", client.getNamespace());
+    }
+}


### PR DESCRIPTION
Signed-off-by: Shivesh Ranjan <shivesh.ranjan@gmail.com>

**Change log description**  
Adds getNamespace api on schemaregistry client. 

**Purpose of the change**  
Fixes #168 

**What the code does**  
Adds new api for getting the namespace on schema registry client. 

**How to verify it**  
Unit test added.