### PR TITLE
Issue 174: Make pravega-common and pravega-shared-auth compile only dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -127,7 +127,8 @@ project('common') {
     dependencies {
         compile group: 'commons-io', name: 'commons-io', version: commonsioVersion
         compile group: 'com.google.guava', name: 'guava', version: guavaVersion
-        compile group: 'io.pravega', name: 'pravega-common', version: pravegaVersion
+        compileOnly group: 'io.pravega', name: 'pravega-common', version: pravegaVersion
+        testCompile group: 'io.pravega', name: 'pravega-common', version: pravegaVersion
         //Do NOT add any additional dependencies to common. All other sub projects depend on common and any project specific 
         //dependency should be added to the specific project. 
     }
@@ -144,7 +145,7 @@ project('common') {
 project('auth') {
     dependencies {
         compile project(':common')
-        compile group: 'io.pravega', name: 'pravega-shared-authplugin', version: pravegaVersion
+        compileOnly group: 'io.pravega', name: 'pravega-shared-authplugin', version: pravegaVersion
     }
 
     javadoc {
@@ -163,9 +164,13 @@ project('client') {
         compile project(':contract')
         compile group: 'org.glassfish.jersey.ext', name: 'jersey-proxy-client', version: jerseyVersion
         compile group: 'org.glassfish.jersey.core', name: 'jersey-client', version: jerseyVersion
+        compileOnly group: 'io.pravega', name: 'pravega-common', version: pravegaVersion
+        compileOnly group: 'io.pravega', name: 'pravega-shared-authplugin', version: pravegaVersion
         testCompile group: 'org.slf4j', name: 'log4j-over-slf4j', version: slf4jApiVersion
         testCompile group: 'ch.qos.logback', name: 'logback-classic', version: qosLogbackVersion
         testCompile group: 'io.pravega', name: 'pravega-test-testcommon', version: pravegaVersion
+        testCompile group: 'io.pravega', name: 'pravega-common', version: pravegaVersion
+        testCompile group: 'io.pravega', name: 'pravega-shared-authplugin', version: pravegaVersion
     }
 
     javadoc {
@@ -192,6 +197,8 @@ project('contract') {
         compile group: 'org.glassfish.jersey.media', name: 'jersey-media-json-jackson', version: jerseyVersion
         compile group: 'javax.xml.bind', name: 'jaxb-api', version: jaxbVersion
         compile group: 'org.glassfish.jaxb', name: 'jaxb-runtime', version: jaxbVersion
+        compileOnly group: 'io.pravega', name: 'pravega-common', version: pravegaVersion
+        testCompile group: 'io.pravega', name: 'pravega-common', version: pravegaVersion
         testCompile group: 'io.pravega', name: 'pravega-test-testcommon', version: pravegaVersion
     }
 
@@ -220,8 +227,10 @@ project('serializers:shared') {
     dependencies {
         compile project(':common')
         compile project(':client')
+        compileOnly group: 'io.pravega', name: 'pravega-common', version: pravegaVersion
         compileOnly group: 'io.pravega', name: 'pravega-client', version: pravegaVersion
         compile group: 'org.xerial.snappy', name: 'snappy-java', version: snappyVersion
+        testCompile group: 'io.pravega', name: 'pravega-common', version: pravegaVersion
         testCompile group: 'org.slf4j', name: 'log4j-over-slf4j', version: slf4jApiVersion
         testCompile group: 'ch.qos.logback', name: 'logback-classic', version: qosLogbackVersion
         testCompile group: 'io.pravega', name: 'pravega-test-testcommon', version: pravegaVersion
@@ -381,6 +390,7 @@ project('serializers') {
         compile project(':serializers:json')
         compile group: 'org.xerial.snappy', name: 'snappy-java', version: snappyVersion
         compileOnly group: 'io.pravega', name: 'pravega-client', version: pravegaVersion
+        compileOnly group: 'io.pravega', name: 'pravega-common', version: pravegaVersion
 
         testCompile project(path:':serializers:shared', configuration:'testRuntime')
         testCompile files(project(':serializers:avro').sourceSets.test.output)
@@ -472,6 +482,8 @@ project('server') {
         compile group: 'com.fasterxml.jackson.module', name: 'jackson-module-jsonSchema', version: jacksonVersion
         compile group: 'com.github.everit-org.json-schema', name: 'org.everit.json.schema', version: everitVersion
         runtime group: 'io.pravega', name: 'pravega-keycloak-client', version: pravegaKeyCloakVersion
+        compile group: 'io.pravega', name: 'pravega-common', version: pravegaVersion
+        compile group: 'io.pravega', name: 'pravega-shared-authplugin', version: pravegaVersion
 
         testCompile (group: 'io.pravega', name: 'pravega-standalone', version: pravegaVersion) {
             exclude group: 'javax.ws.rs', module: 'jsr311-api'


### PR DESCRIPTION
Signed-off-by: Shivesh Ranjan <shivesh.ranjan@gmail.com>

**Change log description**  
Makes pravega-common and pravega-shared-auth compile only dependency on client modules.

**Purpose of the change**  
Fixes #174 

**What the code does**  
Makes praveg common and pravega shared auth as compile only dependencies on pravega client libraries. 
When schema registry clients are used with pravega applications, the pravega client dependency will bring in the requisite dependencies.
However, if schema registry client is used standalone, then users will need to include additional dependencies for pravega-common. 

**How to verify it**  
All tests should pass