### PR TITLE
Issue 182: Add explicit dependency on slf4j and exlude it from other dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -123,10 +123,17 @@ allprojects {
     }
 }
 
+subprojects {
+    task allDeps(type: DependencyReportTask) {}
+}
+
+def withoutLogger = { exclude group: 'org.slf4j', module: 'slf4j-log4j12'
+    exclude group: 'org.slf4j', module: 'slf4j-simple' }
+
 project('common') {
     dependencies {
-        compile group: 'commons-io', name: 'commons-io', version: commonsioVersion
-        compile group: 'com.google.guava', name: 'guava', version: guavaVersion
+        compile group: 'commons-io', name: 'commons-io', version: commonsioVersion, withoutLogger
+        compile group: 'com.google.guava', name: 'guava', version: guavaVersion, withoutLogger
         compileOnly group: 'io.pravega', name: 'pravega-common', version: pravegaVersion
         testCompile group: 'io.pravega', name: 'pravega-common', version: pravegaVersion
         //Do NOT add any additional dependencies to common. All other sub projects depend on common and any project specific 
@@ -162,8 +169,8 @@ project('client') {
         compile project(':common')
         compile project(':auth')
         compile project(':contract')
-        compile group: 'org.glassfish.jersey.ext', name: 'jersey-proxy-client', version: jerseyVersion
-        compile group: 'org.glassfish.jersey.core', name: 'jersey-client', version: jerseyVersion
+        compile group: 'org.glassfish.jersey.ext', name: 'jersey-proxy-client', version: jerseyVersion, withoutLogger
+        compile group: 'org.glassfish.jersey.core', name: 'jersey-client', version: jerseyVersion, withoutLogger
         compileOnly group: 'io.pravega', name: 'pravega-common', version: pravegaVersion
         compileOnly group: 'io.pravega', name: 'pravega-shared-authplugin', version: pravegaVersion
         testCompile group: 'org.slf4j', name: 'log4j-over-slf4j', version: slf4jApiVersion
@@ -188,15 +195,15 @@ project('contract') {
         compile project(':common')
         testCompile group: 'org.slf4j', name: 'log4j-over-slf4j', version: slf4jApiVersion
         testCompile group: 'ch.qos.logback', name: 'logback-classic', version: qosLogbackVersion
-        compile group: 'javax.servlet', name: 'javax.servlet-api', version: javaxServletApiVersion
+        compile group: 'javax.servlet', name: 'javax.servlet-api', version: javaxServletApiVersion, withoutLogger
         compile(group: 'io.swagger', name : 'swagger-jersey2-jaxrs', version :swaggerJersey2JaxrsVersion) {
             exclude group: 'com.google.guava', module: 'guava'
         }
-        compile group: 'org.glassfish.jersey.containers', name: 'jersey-container-grizzly2-http', version: jerseyVersion
-        compile group: 'org.glassfish.jersey.inject', name: 'jersey-hk2', version: jerseyVersion
-        compile group: 'org.glassfish.jersey.media', name: 'jersey-media-json-jackson', version: jerseyVersion
-        compile group: 'javax.xml.bind', name: 'jaxb-api', version: jaxbVersion
-        compile group: 'org.glassfish.jaxb', name: 'jaxb-runtime', version: jaxbVersion
+        compile group: 'org.glassfish.jersey.containers', name: 'jersey-container-grizzly2-http', version: jerseyVersion, withoutLogger
+        compile group: 'org.glassfish.jersey.inject', name: 'jersey-hk2', version: jerseyVersion, withoutLogger
+        compile group: 'org.glassfish.jersey.media', name: 'jersey-media-json-jackson', version: jerseyVersion, withoutLogger
+        compile group: 'javax.xml.bind', name: 'jaxb-api', version: jaxbVersion, withoutLogger
+        compile group: 'org.glassfish.jaxb', name: 'jaxb-runtime', version: jaxbVersion, withoutLogger
         compileOnly group: 'io.pravega', name: 'pravega-common', version: pravegaVersion
         testCompile group: 'io.pravega', name: 'pravega-common', version: pravegaVersion
         testCompile group: 'io.pravega', name: 'pravega-test-testcommon', version: pravegaVersion
@@ -229,7 +236,7 @@ project('serializers:shared') {
         compile project(':client')
         compileOnly group: 'io.pravega', name: 'pravega-common', version: pravegaVersion
         compileOnly group: 'io.pravega', name: 'pravega-client', version: pravegaVersion
-        compile group: 'org.xerial.snappy', name: 'snappy-java', version: snappyVersion
+        compile group: 'org.xerial.snappy', name: 'snappy-java', version: snappyVersion, withoutLogger
         testCompile group: 'io.pravega', name: 'pravega-common', version: pravegaVersion
         testCompile group: 'org.slf4j', name: 'log4j-over-slf4j', version: slf4jApiVersion
         testCompile group: 'ch.qos.logback', name: 'logback-classic', version: qosLogbackVersion
@@ -251,7 +258,7 @@ project('serializers:avro') {
     apply plugin: 'com.github.johnrengelman.shadow'
     dependencies {
         compile project(':serializers:shared')
-        compile group: 'org.apache.avro', name: 'avro', version: avroVersion
+        compile group: 'org.apache.avro', name: 'avro', version: avroVersion, withoutLogger
         compileOnly group: 'io.pravega', name: 'pravega-client', version: pravegaVersion
 
         testCompile project(path:':serializers:shared', configuration:'testRuntime')
@@ -296,8 +303,8 @@ project('serializers:protobuf') {
     apply plugin: 'com.github.johnrengelman.shadow'
     dependencies {
         compile project(':serializers:shared')
-        compile group: 'com.google.protobuf', name: 'protobuf-java', version: protobufProtocVersion
-        compile group: 'com.google.protobuf', name: 'protobuf-java-util', version: protobufUtilVersion
+        compile group: 'com.google.protobuf', name: 'protobuf-java', version: protobufProtocVersion, withoutLogger
+        compile group: 'com.google.protobuf', name: 'protobuf-java-util', version: protobufUtilVersion, withoutLogger
         compileOnly group: 'io.pravega', name: 'pravega-client', version: pravegaVersion
 
         testCompile project(path:':serializers:shared', configuration:'testRuntime')
@@ -341,8 +348,8 @@ project('serializers:json') {
     apply plugin: 'com.github.johnrengelman.shadow'
     dependencies {
         compile project(':serializers:shared')
-        compile group: 'com.github.everit-org.json-schema', name: 'org.everit.json.schema', version: everitVersion
-        compile group: 'com.fasterxml.jackson.module', name: 'jackson-module-jsonSchema', version: jacksonVersion
+        compile group: 'com.github.everit-org.json-schema', name: 'org.everit.json.schema', version: everitVersion, withoutLogger
+        compile group: 'com.fasterxml.jackson.module', name: 'jackson-module-jsonSchema', version: jacksonVersion, withoutLogger
         compileOnly group: 'io.pravega', name: 'pravega-client', version: pravegaVersion
 
         testCompile project(path:':serializers:shared', configuration:'testRuntime')
@@ -388,7 +395,7 @@ project('serializers') {
         compile project(':serializers:avro')
         compile project(':serializers:protobuf')
         compile project(':serializers:json')
-        compile group: 'org.xerial.snappy', name: 'snappy-java', version: snappyVersion
+        compile group: 'org.xerial.snappy', name: 'snappy-java', version: snappyVersion, withoutLogger
         compileOnly group: 'io.pravega', name: 'pravega-client', version: pravegaVersion
         compileOnly group: 'io.pravega', name: 'pravega-common', version: pravegaVersion
 
@@ -473,17 +480,19 @@ project('server') {
         compile project(':common')
         compile project(':auth')
         compile project(':contract')
-        compile group: 'io.pravega', name: 'pravega-client', version: pravegaVersion
-        compile group: 'io.pravega', name: 'pravega-shared-basic-authplugin', version: pravegaVersion
-        compile group: 'org.apache.avro', name: 'avro', version: avroVersion
-        compile group: 'org.apache.avro', name: 'avro-protobuf', version: avroProtobufVersion
-        compile group: 'com.google.protobuf', name: 'protobuf-java-util', version: protobufUtilVersion
-        compile group: 'com.google.protobuf', name: 'protobuf-java', version: protobufProtocVersion
-        compile group: 'com.fasterxml.jackson.module', name: 'jackson-module-jsonSchema', version: jacksonVersion
-        compile group: 'com.github.everit-org.json-schema', name: 'org.everit.json.schema', version: everitVersion
+        compile group: 'io.pravega', name: 'pravega-client', version: pravegaVersion, withoutLogger
+        compile group: 'io.pravega', name: 'pravega-shared-basic-authplugin', version: pravegaVersion, withoutLogger
+        compile group: 'org.apache.avro', name: 'avro', version: avroVersion, withoutLogger
+        compile group: 'org.apache.avro', name: 'avro-protobuf', version: avroProtobufVersion, withoutLogger
+        compile group: 'com.google.protobuf', name: 'protobuf-java-util', version: protobufUtilVersion, withoutLogger
+        compile group: 'com.google.protobuf', name: 'protobuf-java', version: protobufProtocVersion, withoutLogger
+        compile group: 'com.fasterxml.jackson.module', name: 'jackson-module-jsonSchema', version: jacksonVersion, withoutLogger
+        compile group: 'com.github.everit-org.json-schema', name: 'org.everit.json.schema', version: everitVersion, withoutLogger
         runtime group: 'io.pravega', name: 'pravega-keycloak-client', version: pravegaKeyCloakVersion
-        compile group: 'io.pravega', name: 'pravega-common', version: pravegaVersion
-        compile group: 'io.pravega', name: 'pravega-shared-authplugin', version: pravegaVersion
+        compile group: 'io.pravega', name: 'pravega-common', version: pravegaVersion, withoutLogger
+        compile group: 'io.pravega', name: 'pravega-shared-authplugin', version: pravegaVersion, withoutLogger
+        compile group: 'org.slf4j', name: 'log4j-over-slf4j', version: slf4jApiVersion
+        compile group: 'org.slf4j', name: 'slf4j-simple', version: slf4jApiVersion
 
         testCompile (group: 'io.pravega', name: 'pravega-standalone', version: pravegaVersion) {
             exclude group: 'javax.ws.rs', module: 'jsr311-api'


### PR DESCRIPTION
Signed-off-by: Shivesh Ranjan <shivesh.ranjan@gmail.com>

**Change log description**  
While including slf4j we should make sure it does not clash with any transitive dependency that we include so we should explicitly exclude it. 
also, add slf4j dependency explicitly. 

**Purpose of the change**  
Fixes #182 

**What the code does**  
Adds slf4j dependency explicitly to schema registry server. and exclude slf4j from other dependencies. 

**How to verify it**  
All tests should pass and docker run should show the logs