### PR TITLE
Issue 184: Retry on auth failures in calls to segment store

### DIFF
--- a/client/src/main/java/io/pravega/schemaregistry/client/SchemaRegistryClientImpl.java
+++ b/client/src/main/java/io/pravega/schemaregistry/client/SchemaRegistryClientImpl.java
@@ -228,9 +228,9 @@ public class SchemaRegistryClientImpl implements SchemaRegistryClient {
     private List<SchemaWithVersion> latestSchemas(String groupId, String type) {
         return withRetry(() -> {
             Response response = groupProxy.getSchemas(namespace, groupId, type);
-            SchemaVersionsList objectsList = response.readEntity(SchemaVersionsList.class);
             switch (Response.Status.fromStatusCode(response.getStatus())) {
                 case OK:
+                    SchemaVersionsList objectsList = response.readEntity(SchemaVersionsList.class);
                     return objectsList.getSchemas().stream().map(ModelHelper::decode).collect(Collectors.toList());
                 case NOT_FOUND:
                     throw new ResourceNotFoundException("Group not found.");
@@ -448,9 +448,9 @@ public class SchemaRegistryClientImpl implements SchemaRegistryClient {
     public List<CodecType> getCodecTypes(String groupId) {
         return withRetry(() -> {
             Response response = groupProxy.getCodecTypesList(namespace, groupId);
-            CodecTypes list = response.readEntity(CodecTypes.class);
             switch (Response.Status.fromStatusCode(response.getStatus())) {
                 case OK:
+                    CodecTypes list = response.readEntity(CodecTypes.class);
                     return list.getCodecTypes().stream().map(ModelHelper::decode).collect(Collectors.toList());
                 case NOT_FOUND:
                     throw new ResourceNotFoundException("Group not found.");

--- a/client/src/test/java/io/pravega/schemaregistry/client/TestSchemaRegistryClient.java
+++ b/client/src/test/java/io/pravega/schemaregistry/client/TestSchemaRegistryClient.java
@@ -379,6 +379,9 @@ public class TestSchemaRegistryClient {
         SchemaWithVersion schemaWithVersion1 = client.getLatestSchemaVersion("mygroup", null);
         assertEquals(schemaWithVersion.getSchemaInfo(), schemaWithVersion1.getSchemaInfo());
         assertEquals(schemaWithVersion.getVersionInfo(), schemaWithVersion1.getVersionInfo());
+
+        doThrow(new RuntimeException()).when(response).readEntity(
+                SchemaVersionsList.class);
         // NotFound Exception
         doReturn(Response.Status.NOT_FOUND.getStatusCode()).when(response).getStatus();
         AssertExtensions.assertThrows("An exception should have been thrown",
@@ -388,6 +391,8 @@ public class TestSchemaRegistryClient {
         AssertExtensions.assertThrows("An exception should have been thrown",
                 () -> client.getLatestSchemaVersion("mygroup", null), e -> e instanceof InternalServerError);
 
+        doReturn(schemaWithVersions).when(response).readEntity(
+                SchemaVersionsList.class);
         doReturn(Response.Status.OK.getStatusCode()).when(response).getStatus();
         serializationFormat = SerializationFormat.custom("custom");
         versionInfo = new VersionInfo("schema2", serializationFormat.getFullTypeName(), 5, 5);


### PR DESCRIPTION
Signed-off-by: Shivesh Ranjan <shivesh.ranjan@gmail.com>

**Change log description**  
Fixes two problems as were found in issue 184:
1. Registry doesnt retry on auth failures but fails the rest call with internal server 500. we should retry on auth failures too. 
2. on registry client in two apis, `latest schema` and `listcodecs` we actually read entity before checking if the entity is indeed present which would be the case when the return code is http.ok.

**Purpose of the change**  
Fixes #184

**What the code does**  
Changes retry condition in tablestore to also retry on auth exception.
Fixes the registry client for two apis where we read entity only if the response was success.

**How to verify it**  
Unit tests added
