### PR TITLE
Issue 179: Use latest pravega key cloak client library version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -48,7 +48,7 @@ avroVersion=1.9.1
 avroProtobufVersion=1.7.7
 snappyVersion=1.1.7.3
 pravegaVersion=0.9.0-2705.09f82eb-SNAPSHOT
-pravegaKeyCloakVersion=0.8.0
+pravegaKeyCloakVersion=0.9.0-36.ad03b19-SNAPSHOT
 
 # Version and base tags can be overridden at build time
 schemaregistryVersion=0.2.0-SNAPSHOT


### PR DESCRIPTION
Signed-off-by: Shivesh Ranjan <shivesh.ranjan@gmail.com>

**Change log description**  
Changes to use latest pravega keycloak client version 0.9.0-36.ad03b19-SNAPSHOT

**Purpose of the change**  
Fixes #179 

**What the code does**  
uses latest keycloak client version

**How to verify it**  
All tests should pass