### PR TITLE
Fix bug in schema deletion

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -283,7 +283,7 @@ project('serializers:avro') {
         classifier ='all'
         mergeServiceFiles()
     }
-    
+
     tasks.build.dependsOn tasks.shadowJar
     artifacts { archives shadowJar }
     javadoc {
@@ -405,7 +405,7 @@ project('serializers') {
         testCompile group: 'io.pravega', name: 'pravega-test-testcommon', version: pravegaVersion
         testCompile group: 'io.pravega', name: 'pravega-client', version: pravegaVersion
     }
-    
+
     shadowJar {
         zip64 true
         relocate 'org.xerial.snappy' , 'io.pravega.schemaregistry.shaded.org.xerial.snappy'
@@ -423,7 +423,7 @@ project('serializers') {
         classifier ='all'
         mergeServiceFiles()
     }
-    
+
     tasks.build.dependsOn tasks.shadowJar
     artifacts { archives shadowJar }
     javadoc {
@@ -526,7 +526,7 @@ project('test') {
         compile project(':common')
         compile project(':contract')
         compile project(':client')
-        compile project(':server') 
+        compile project(':server')
         compile project(':serializers')
         compile project(':serializers:protobuf')
         compile project(':serializers:avro')
@@ -752,4 +752,3 @@ class DockerPushTask extends Exec {
         }
     }
 }
-

--- a/build.gradle
+++ b/build.gradle
@@ -405,6 +405,18 @@ project('serializers') {
         testCompile group: 'io.pravega', name: 'pravega-test-testcommon', version: pravegaVersion
         testCompile group: 'io.pravega', name: 'pravega-client', version: pravegaVersion
     }
+    
+    shadowJar {
+        //classifier = 'tests'
+        //from sourceSets.test.output
+        //configurations = [project.configurations.testRuntime]
+        zip64 true
+        relocate 'org.apache.avro', 'io.pravega.schemaregistry.shaded.org.apache.avro'
+        classifier ='all'
+        mergeServiceFiles()
+    }
+    
+    tasks.build.dependsOn tasks.shadowJar
 
     shadowJar {
         zip64 true

--- a/build.gradle
+++ b/build.gradle
@@ -283,7 +283,7 @@ project('serializers:avro') {
         classifier ='all'
         mergeServiceFiles()
     }
-
+    
     tasks.build.dependsOn tasks.shadowJar
     artifacts { archives shadowJar }
     javadoc {
@@ -407,18 +407,6 @@ project('serializers') {
     }
     
     shadowJar {
-        //classifier = 'tests'
-        //from sourceSets.test.output
-        //configurations = [project.configurations.testRuntime]
-        zip64 true
-        relocate 'org.apache.avro', 'io.pravega.schemaregistry.shaded.org.apache.avro'
-        classifier ='all'
-        mergeServiceFiles()
-    }
-    
-    tasks.build.dependsOn tasks.shadowJar
-
-    shadowJar {
         zip64 true
         relocate 'org.xerial.snappy' , 'io.pravega.schemaregistry.shaded.org.xerial.snappy'
         relocate 'org.glassfish.jersey.ext' , 'io.pravega.schemaregistry.shaded.org.glassfish.jersey.ext'
@@ -435,7 +423,7 @@ project('serializers') {
         classifier ='all'
         mergeServiceFiles()
     }
-
+    
     tasks.build.dependsOn tasks.shadowJar
     artifacts { archives shadowJar }
     javadoc {
@@ -538,7 +526,7 @@ project('test') {
         compile project(':common')
         compile project(':contract')
         compile project(':client')
-        compile project(':server')
+        compile project(':server') 
         compile project(':serializers')
         compile project(':serializers:protobuf')
         compile project(':serializers:avro')
@@ -764,3 +752,4 @@ class DockerPushTask extends Exec {
         }
     }
 }
+

--- a/server/src/main/java/io/pravega/schemaregistry/storage/impl/group/Group.java
+++ b/server/src/main/java/io/pravega/schemaregistry/storage/impl/group/Group.java
@@ -309,7 +309,7 @@ public class Group<V> {
                             // we are deleting the latest schema for the type.. we need to find the previous non deleted schema
                             // for the type
                             // first find the highest non deleted version number for the type.  
-                            AtomicInteger previous = new AtomicInteger(value.getLatestId() - 1);
+                            AtomicInteger previous = new AtomicInteger(value.getLatestVersion() - 1);
                             while (deletedVersions.contains(previous.get())) {
                                 previous.decrementAndGet();
                             }

--- a/server/src/test/java/io/pravega/schemaregistry/storage/impl/group/GroupPravegaTest.java
+++ b/server/src/test/java/io/pravega/schemaregistry/storage/impl/group/GroupPravegaTest.java
@@ -674,6 +674,11 @@ public class GroupPravegaTest {
                 HashUtil.getFingerprint(schemaInfo.getSchemaData().array()), groupProperties, eTag).join();
         eTag = pravegaKeyValueGroups.getGroup(null, groupName).join().getCurrentEtag().join();
         schemaData = new byte[5];
+        schemaInfo = new SchemaInfo(anygroup, SerializationFormat.Avro, ByteBuffer.wrap(schemaData),
+                ImmutableMap.of());
+        pravegaKeyValueGroups.getGroup(null, groupName).join().addSchema(schemaInfo,
+                HashUtil.getFingerprint(schemaInfo.getSchemaData().array()), groupProperties, eTag).join();
+        eTag = pravegaKeyValueGroups.getGroup(null, groupName).join().getCurrentEtag().join();
         schemaInfo = new SchemaInfo(anygroup1, SerializationFormat.Avro, ByteBuffer.wrap(schemaData),
                 ImmutableMap.of());
         BigInteger fingerprint = HashUtil.getFingerprint(schemaInfo.getSchemaData().array());

--- a/server/src/test/java/io/pravega/schemaregistry/storage/impl/group/GroupTest.java
+++ b/server/src/test/java/io/pravega/schemaregistry/storage/impl/group/GroupTest.java
@@ -498,7 +498,7 @@ public class GroupTest {
         schemaData = new byte[5];
         schemaInfo = new SchemaInfo(anygroup1, SerializationFormat.Custom, ByteBuffer.wrap(schemaData),
                 ImmutableMap.of());
-        inMemoryGroup.addSchema(schemaInfo, HashUtil.getFingerprint(schemaInfo.getSchemaData().array()), groupProperties, eTag);
+        inMemoryGroup.addSchema(schemaInfo, HashUtil.getFingerprint(schemaInfo.getSchemaData().array()), groupProperties, eTag).join();
         VersionInfo versionInfo1 = inMemoryGroup.getVersion(schemaInfo, HashUtil.getFingerprint(schemaInfo.getSchemaData().array())).join();
         eTag = inMemoryGroup.getCurrentEtag().join();
         EncodingId encodingId1 = inMemoryGroup.createEncodingId(versionInfo1, "snappy", eTag).join();
@@ -599,7 +599,7 @@ public class GroupTest {
         schemaData = new byte[5];
         SchemaInfo schemaInfo2 = new SchemaInfo(anygroup1, SerializationFormat.Custom, ByteBuffer.wrap(schemaData),
                 ImmutableMap.of());
-        inMemoryGroup.addSchema(schemaInfo2, HashUtil.getFingerprint(schemaInfo2.getSchemaData().array()), groupProperties, eTag);
+        inMemoryGroup.addSchema(schemaInfo2, HashUtil.getFingerprint(schemaInfo2.getSchemaData().array()), groupProperties, eTag).join();
         VersionInfo versionInfo1 = inMemoryGroup.getVersion(schemaInfo2, HashUtil.getFingerprint(schemaInfo2.getSchemaData().array())).join();
         SchemaInfo schemaInfo3 = inMemoryGroup.getSchema(versionInfo1.getType(), versionInfo1.getVersion(),
                 schemaInfo1.getSerializationFormat().getFullTypeName()).join();

--- a/server/src/test/java/io/pravega/schemaregistry/storage/impl/group/GroupTest.java
+++ b/server/src/test/java/io/pravega/schemaregistry/storage/impl/group/GroupTest.java
@@ -525,9 +525,13 @@ public class GroupTest {
         inMemoryGroup.addSchema(schemaInfo, HashUtil.getFingerprint(schemaInfo.getSchemaData().array()), groupProperties, eTag).join();
         eTag = inMemoryGroup.getCurrentEtag().join();
         schemaData = new byte[5];
+        schemaInfo = new SchemaInfo(anygroup, SerializationFormat.Custom, ByteBuffer.wrap(schemaData),
+                ImmutableMap.of());
+        inMemoryGroup.addSchema(schemaInfo, HashUtil.getFingerprint(schemaInfo.getSchemaData().array()), groupProperties, eTag).join();
+        eTag = inMemoryGroup.getCurrentEtag().join();
         schemaInfo = new SchemaInfo(anygroup1, SerializationFormat.Custom, ByteBuffer.wrap(schemaData),
                 ImmutableMap.of());
-        inMemoryGroup.addSchema(schemaInfo, HashUtil.getFingerprint(schemaInfo.getSchemaData().array()), groupProperties, eTag);
+        inMemoryGroup.addSchema(schemaInfo, HashUtil.getFingerprint(schemaInfo.getSchemaData().array()), groupProperties, eTag).join();
         VersionInfo versionInfo = inMemoryGroup.getVersion(schemaInfo, HashUtil.getFingerprint(schemaInfo.getSchemaData().array())).join();
         eTag = inMemoryGroup.getCurrentEtag().join();
         inMemoryGroup.deleteSchema(versionInfo.getId(), eTag).join();


### PR DESCRIPTION
**Change log description**  
Use latest version instead of latest Id when computing the previous version for latest schema deletion.

**Purpose of the change**  
Fixes #187 

**What the code does**  
The deleteSchema (id,etag) method erroneously uses latest id instead of latest version when computing the previous highest non-deleted schema version for the type. The fix changes the previous version computation to use latest version for the type instead of latest id.

**How to verify it**  
Run the schema delete unit test in GroupTest.java
