### PR TITLE
Issue 189: Token failure should be retried for updateTable calls

### DIFF
--- a/server/src/main/java/io/pravega/schemaregistry/storage/client/TableStore.java
+++ b/server/src/main/java/io/pravega/schemaregistry/storage/client/TableStore.java
@@ -195,7 +195,7 @@ public class TableStore extends AbstractService {
                                                    .collect(Collectors.toList()))
                                 .whenComplete((r, e) -> {
                                 releaseEntries(entries);
-                            }), () -> String.format("delete table: %s", tableName), tableName);
+                            }), () -> String.format("updateEntries in table: %s", tableName), tableName);
     }
 
     public <T> CompletableFuture<VersionedRecord<T>> getEntry(String tableName, byte[] key, Function<byte[], T> fromBytes) {

--- a/server/src/main/java/io/pravega/schemaregistry/storage/client/TableStore.java
+++ b/server/src/main/java/io/pravega/schemaregistry/storage/client/TableStore.java
@@ -64,11 +64,11 @@ public class TableStore extends AbstractService {
     private final static int RETRY_MULTIPLIER = 2;
     private final static long RETRY_MAX_DELAY = Duration.ofSeconds(5).toMillis();
     private static final int NUM_OF_RETRIES = 15; // approximately 1 minute worth of retries
-    public static final Predicate<Throwable> TOKEN_RETRY_PREDICATE = e -> {
+    private static final Predicate<Throwable> TOKEN_RETRY_PREDICATE = e -> {
         Throwable unwrap = Exceptions.unwrap(e);
         return unwrap instanceof StoreExceptions.TokenException;
     };
-    public static final Predicate<Throwable> RETRY_PREDICATE = e -> {
+    private static final Predicate<Throwable> RETRY_PREDICATE = e -> {
         Throwable unwrap = Exceptions.unwrap(e);
         return unwrap instanceof StoreExceptions.StoreConnectionException ||
                 unwrap instanceof StoreExceptions.TokenException;

--- a/server/src/test/java/io/pravega/schemaregistry/storage/client/TablesStoreTest.java
+++ b/server/src/test/java/io/pravega/schemaregistry/storage/client/TablesStoreTest.java
@@ -212,9 +212,9 @@ public class TablesStoreTest {
         TableStore tableStore = new TableStore(wireCommandClient, executor, 2);
         Map<byte[], VersionedRecord<byte[]>> map = Collections.singletonMap(new byte[10], new VersionedRecord<>(new byte[10], Version.NO_VERSION));
         AssertExtensions.assertFutureThrows("retries did not exhaust", 
-                tableStore.updateEntries("t/t", map), e -> Exceptions.unwrap(e) instanceof StoreExceptions.StoreConnectionException);
+                tableStore.updateEntries("t/t", map), e -> Exceptions.unwrap(e) instanceof RetriesExhaustedException);
         // verify it is not retried. 
-        verify(wireCommandClient, times(1)).updateTableEntries(any(), any(), any());
+        verify(wireCommandClient, times(2)).updateTableEntries(any(), any(), any());
 
         // auth error
         wireCommandClient = WireCommandMock.getFailingMock(() -> 

--- a/server/src/test/java/io/pravega/schemaregistry/storage/client/TablesStoreTest.java
+++ b/server/src/test/java/io/pravega/schemaregistry/storage/client/TablesStoreTest.java
@@ -213,7 +213,7 @@ public class TablesStoreTest {
         Map<byte[], VersionedRecord<byte[]>> map = Collections.singletonMap(new byte[10], new VersionedRecord<>(new byte[10], Version.NO_VERSION));
         AssertExtensions.assertFutureThrows("retries did not exhaust", 
                 tableStore.updateEntries("t/t", map), e -> Exceptions.unwrap(e) instanceof RetriesExhaustedException);
-        // verify it is not retried. 
+        // verify it is retried. 
         verify(wireCommandClient, times(2)).updateTableEntries(any(), any(), any());
 
         // auth error


### PR DESCRIPTION
Signed-off-by: Shivesh Ranjan <shivesh.ranjan@gmail.com>

**Change log description**  
Token failure exception for upadteTableEntries should be retried. 

**Purpose of the change**  
Fixes #189 

**What the code does**  
Adds a retry logic for updateTableEntries for the token failure exception. 

**How to verify it**  
Unit test added.
