### PR TITLE
Issue 205: Enabled Timestamps in Schema Registry logs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -535,7 +535,6 @@ project('test') {
         compile project(':serializers:json')
         compile project(':serializers:shared')
         compile group: 'io.pravega', name: 'pravega-client', version: pravegaVersion
-        compile group: 'ch.qos.logback', name: 'logback-classic', version: qosLogbackVersion
 
         testCompile (group: 'io.pravega', name: 'pravega-standalone', version: pravegaVersion) {
             exclude group: 'javax.ws.rs', module: 'jsr311-api'

--- a/build.gradle
+++ b/build.gradle
@@ -169,6 +169,7 @@ project('client') {
         compile project(':contract')
         compile group: 'org.glassfish.jersey.ext', name: 'jersey-proxy-client', version: jerseyVersion, withoutLogger
         compile group: 'org.glassfish.jersey.core', name: 'jersey-client', version: jerseyVersion, withoutLogger
+        compile group: 'ch.qos.logback', name: 'logback-classic', version: qosLogbackVersion
         compileOnly group: 'io.pravega', name: 'pravega-common', version: pravegaVersion
         compileOnly group: 'io.pravega', name: 'pravega-shared-authplugin', version: pravegaVersion
         testCompile group: 'org.slf4j', name: 'log4j-over-slf4j', version: slf4jApiVersion
@@ -193,6 +194,7 @@ project('contract') {
         compile project(':common')
         testCompile group: 'org.slf4j', name: 'log4j-over-slf4j', version: slf4jApiVersion
         testCompile group: 'ch.qos.logback', name: 'logback-classic', version: qosLogbackVersion
+        compile group: 'ch.qos.logback', name: 'logback-classic', version: qosLogbackVersion
         compile group: 'javax.servlet', name: 'javax.servlet-api', version: javaxServletApiVersion, withoutLogger
         compile(group: 'io.swagger', name : 'swagger-jersey2-jaxrs', version :swaggerJersey2JaxrsVersion) {
             exclude group: 'com.google.guava', module: 'guava'
@@ -235,6 +237,7 @@ project('serializers:shared') {
         compileOnly group: 'io.pravega', name: 'pravega-common', version: pravegaVersion
         compileOnly group: 'io.pravega', name: 'pravega-client', version: pravegaVersion
         compile group: 'org.xerial.snappy', name: 'snappy-java', version: snappyVersion, withoutLogger
+        compile group: 'ch.qos.logback', name: 'logback-classic', version: qosLogbackVersion
         testCompile group: 'io.pravega', name: 'pravega-common', version: pravegaVersion
         testCompile group: 'org.slf4j', name: 'log4j-over-slf4j', version: slf4jApiVersion
         testCompile group: 'ch.qos.logback', name: 'logback-classic', version: qosLogbackVersion
@@ -257,6 +260,7 @@ project('serializers:avro') {
     dependencies {
         compile project(':serializers:shared')
         compile group: 'org.apache.avro', name: 'avro', version: avroVersion, withoutLogger
+        compile group: 'ch.qos.logback', name: 'logback-classic', version: qosLogbackVersion
         compileOnly group: 'io.pravega', name: 'pravega-client', version: pravegaVersion
 
         testCompile project(path:':serializers:shared', configuration:'testRuntime')
@@ -303,6 +307,7 @@ project('serializers:protobuf') {
         compile project(':serializers:shared')
         compile group: 'com.google.protobuf', name: 'protobuf-java', version: protobufProtocVersion, withoutLogger
         compile group: 'com.google.protobuf', name: 'protobuf-java-util', version: protobufUtilVersion, withoutLogger
+        compile group: 'ch.qos.logback', name: 'logback-classic', version: qosLogbackVersion
         compileOnly group: 'io.pravega', name: 'pravega-client', version: pravegaVersion
 
         testCompile project(path:':serializers:shared', configuration:'testRuntime')
@@ -348,6 +353,7 @@ project('serializers:json') {
         compile project(':serializers:shared')
         compile group: 'com.github.erosb', name: 'everit-json-schema', version: everitVersion, withoutLogger
         compile group: 'com.fasterxml.jackson.module', name: 'jackson-module-jsonSchema', version: jacksonVersion, withoutLogger
+        compile group: 'ch.qos.logback', name: 'logback-classic', version: qosLogbackVersion
         compileOnly group: 'io.pravega', name: 'pravega-client', version: pravegaVersion
 
         testCompile project(path:':serializers:shared', configuration:'testRuntime')
@@ -394,6 +400,7 @@ project('serializers') {
         compile project(':serializers:protobuf')
         compile project(':serializers:json')
         compile group: 'org.xerial.snappy', name: 'snappy-java', version: snappyVersion, withoutLogger
+        compile group: 'ch.qos.logback', name: 'logback-classic', version: qosLogbackVersion
         compileOnly group: 'io.pravega', name: 'pravega-client', version: pravegaVersion
         compileOnly group: 'io.pravega', name: 'pravega-common', version: pravegaVersion
 
@@ -485,6 +492,7 @@ project('server') {
         compile group: 'com.google.protobuf', name: 'protobuf-java-util', version: protobufUtilVersion, withoutLogger
         compile group: 'com.google.protobuf', name: 'protobuf-java', version: protobufProtocVersion, withoutLogger
         compile group: 'com.fasterxml.jackson.module', name: 'jackson-module-jsonSchema', version: jacksonVersion, withoutLogger
+        compile group: 'ch.qos.logback', name: 'logback-classic', version: qosLogbackVersion
         compile group: 'com.github.erosb', name: 'everit-json-schema', version: everitVersion, withoutLogger
         runtime group: 'io.pravega', name: 'pravega-keycloak-client', version: pravegaKeyCloakVersion
         compile group: 'io.pravega', name: 'pravega-common', version: pravegaVersion, withoutLogger
@@ -534,6 +542,7 @@ project('test') {
         compile project(':serializers:json')
         compile project(':serializers:shared')
         compile group: 'io.pravega', name: 'pravega-client', version: pravegaVersion
+        compile group: 'ch.qos.logback', name: 'logback-classic', version: qosLogbackVersion
 
         testCompile (group: 'io.pravega', name: 'pravega-standalone', version: pravegaVersion) {
             exclude group: 'javax.ws.rs', module: 'jsr311-api'

--- a/build.gradle
+++ b/build.gradle
@@ -499,7 +499,6 @@ project('server') {
         testCompile group: 'io.pravega', name: 'pravega-shared-basic-authplugin', version: pravegaVersion
         testCompile group: 'io.pravega', name: 'pravega-test-testcommon', version: pravegaVersion
         testCompile group: 'org.slf4j', name: 'log4j-over-slf4j', version: slf4jApiVersion
-        testCompile group: 'ch.qos.logback', name: 'logback-classic', version: qosLogbackVersion
         testCompile group: 'org.glassfish.jersey.test-framework.providers', name: 'jersey-test-framework-provider-grizzly2', version: jerseyVersion
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -169,7 +169,6 @@ project('client') {
         compile project(':contract')
         compile group: 'org.glassfish.jersey.ext', name: 'jersey-proxy-client', version: jerseyVersion, withoutLogger
         compile group: 'org.glassfish.jersey.core', name: 'jersey-client', version: jerseyVersion, withoutLogger
-        compile group: 'ch.qos.logback', name: 'logback-classic', version: qosLogbackVersion
         compileOnly group: 'io.pravega', name: 'pravega-common', version: pravegaVersion
         compileOnly group: 'io.pravega', name: 'pravega-shared-authplugin', version: pravegaVersion
         testCompile group: 'org.slf4j', name: 'log4j-over-slf4j', version: slf4jApiVersion
@@ -194,7 +193,6 @@ project('contract') {
         compile project(':common')
         testCompile group: 'org.slf4j', name: 'log4j-over-slf4j', version: slf4jApiVersion
         testCompile group: 'ch.qos.logback', name: 'logback-classic', version: qosLogbackVersion
-        compile group: 'ch.qos.logback', name: 'logback-classic', version: qosLogbackVersion
         compile group: 'javax.servlet', name: 'javax.servlet-api', version: javaxServletApiVersion, withoutLogger
         compile(group: 'io.swagger', name : 'swagger-jersey2-jaxrs', version :swaggerJersey2JaxrsVersion) {
             exclude group: 'com.google.guava', module: 'guava'
@@ -237,7 +235,6 @@ project('serializers:shared') {
         compileOnly group: 'io.pravega', name: 'pravega-common', version: pravegaVersion
         compileOnly group: 'io.pravega', name: 'pravega-client', version: pravegaVersion
         compile group: 'org.xerial.snappy', name: 'snappy-java', version: snappyVersion, withoutLogger
-        compile group: 'ch.qos.logback', name: 'logback-classic', version: qosLogbackVersion
         testCompile group: 'io.pravega', name: 'pravega-common', version: pravegaVersion
         testCompile group: 'org.slf4j', name: 'log4j-over-slf4j', version: slf4jApiVersion
         testCompile group: 'ch.qos.logback', name: 'logback-classic', version: qosLogbackVersion
@@ -260,7 +257,6 @@ project('serializers:avro') {
     dependencies {
         compile project(':serializers:shared')
         compile group: 'org.apache.avro', name: 'avro', version: avroVersion, withoutLogger
-        compile group: 'ch.qos.logback', name: 'logback-classic', version: qosLogbackVersion
         compileOnly group: 'io.pravega', name: 'pravega-client', version: pravegaVersion
 
         testCompile project(path:':serializers:shared', configuration:'testRuntime')
@@ -307,7 +303,6 @@ project('serializers:protobuf') {
         compile project(':serializers:shared')
         compile group: 'com.google.protobuf', name: 'protobuf-java', version: protobufProtocVersion, withoutLogger
         compile group: 'com.google.protobuf', name: 'protobuf-java-util', version: protobufUtilVersion, withoutLogger
-        compile group: 'ch.qos.logback', name: 'logback-classic', version: qosLogbackVersion
         compileOnly group: 'io.pravega', name: 'pravega-client', version: pravegaVersion
 
         testCompile project(path:':serializers:shared', configuration:'testRuntime')
@@ -353,7 +348,6 @@ project('serializers:json') {
         compile project(':serializers:shared')
         compile group: 'com.github.erosb', name: 'everit-json-schema', version: everitVersion, withoutLogger
         compile group: 'com.fasterxml.jackson.module', name: 'jackson-module-jsonSchema', version: jacksonVersion, withoutLogger
-        compile group: 'ch.qos.logback', name: 'logback-classic', version: qosLogbackVersion
         compileOnly group: 'io.pravega', name: 'pravega-client', version: pravegaVersion
 
         testCompile project(path:':serializers:shared', configuration:'testRuntime')
@@ -400,7 +394,6 @@ project('serializers') {
         compile project(':serializers:protobuf')
         compile project(':serializers:json')
         compile group: 'org.xerial.snappy', name: 'snappy-java', version: snappyVersion, withoutLogger
-        compile group: 'ch.qos.logback', name: 'logback-classic', version: qosLogbackVersion
         compileOnly group: 'io.pravega', name: 'pravega-client', version: pravegaVersion
         compileOnly group: 'io.pravega', name: 'pravega-common', version: pravegaVersion
 


### PR DESCRIPTION
Signed-off-by: SaiCharan <kotlasaicharan@yahoo.com>

**Change log description**  

1. `Logback` is added to the compile dependency in `build.gradle.`
2. Any changes in `server/src/conf/logback.xml` are not reflected being of this dependency being missed out.
3. Timestamp is attached to logs. Below are example logs.
```
2021-07-28 03:20:16,344 478  [main] INFO  i.p.schemaregistry.service.Config - java.vm.name = OpenJDK 64-Bit Server VM
2021-07-28 03:20:16,344 478  [main] INFO  i.p.schemaregistry.service.Config - java.vendor.url.bug = https://bugs.launchpad.net/ubuntu/+source/openjdk-lts
2021-07-28 03:20:16,344 478  [main] INFO  i.p.schemaregistry.service.Config - user.dir = /home/saicharan/schema-registry/build/distributions/schema-registry-0.3.0-66.ae51296-SNAPSHOT
2021-07-28 03:20:16,344 478  [main] INFO  i.p.schemaregistry.service.Config - os.arch = amd64
2021-07-28 03:20:16,345 479  [main] INFO  i.p.schemaregistry.service.Config - GPG_AGENT_INFO = /run/user/1000/gnupg/S.gpg-agent:0:1
2021-07-28 03:20:16,345 479  [main] INFO  i.p.schemaregistry.service.Config - USER = saicharan
2021-07-28 03:20:16,346 480  [main] INFO  i.p.schemaregistry.service.Config - WINDOWPATH = 2
2021-07-28 03:20:16,346 480  [main] INFO  i.p.schemaregistry.service.Config - SSH_AUTH_SOCK = /run/user/1000/keyring/ssh
2021-07-28 03:20:16,347 481  [main] INFO  i.p.schemaregistry.service.Config - java.vm.info = mixed mode, sharing
2021-07-28 03:20:16,347 481  [main] INFO  i.p.schemaregistry.service.Config - java.vm.version = 11.0.11+9-Ubuntu-0ubuntu2.20.04
2021-07-28 03:20:16,347 481  [main] INFO  i.p.schemaregistry.service.Config - GNOME_SHELL_SESSION_MODE = ubuntu
2021-07-28 03:20:16,347 481  [main] INFO  i.p.schemaregistry.service.Config - config.file = /home/saicharan/schema-registry/build/distributions/schema-registry-0.3.0-66.ae51296-SNAPSHOT/conf/schema-registry.config.properties
2021-07-28 03:20:16,347 481  [main] INFO  i.p.schemaregistry.service.Config - XDG_RUNTIME_DIR = /run/user/1000
2021-07-28 03:20:16,347 481  [main] INFO  i.p.schemaregistry.service.Config - java.class.version = 55.0
2021-07-28 03:20:16,347 481  [main] INFO  i.p.schemaregistry.service.Config - HOME = /home/saicharan
```

 

**Purpose of the change**  
Fixes #205

**What the code does**  
`compile group: 'ch.qos.logback', name: 'logback-classic', version: qosLogbackVersion` is added in the build.gradle file

**How to verify it**  

- Run Schema Registry locally.
- Timestamp are attached to logs being appended to the Console and Log files. 
