### PR TITLE
issue-208 Add support for Custom POD Annotations

### DIFF
--- a/charts/schema-registry/README.md
+++ b/charts/schema-registry/README.md
@@ -57,6 +57,7 @@ The following table lists the configurable parameters of the schema registry cha
 | `serviceAccount.annotations` | Annotations to be added to the service account | |
 | `service.type` | Schema registry service type | `LoadBalancer` |
 | `service.port` | Schema registry service port | `9092` |
+| `podAnnotations` | Custom Annotations that should be applied to the POD | `{}` |
 | `initContainer` | Configuration for the init container | `{}` |
 | `container` | Additional configuration for the schema registry container, to be provided if an init container has been configured | `{}` |
 | `ingress.enabled` | Whether to expose as an ingress resource | `false` |

--- a/charts/schema-registry/templates/deployment.yaml
+++ b/charts/schema-registry/templates/deployment.yaml
@@ -26,6 +26,8 @@ spec:
     metadata:
       labels:
 {{ include "schema-registry.selectorLabels" . | indent 8 }}
+      annotations:
+{{ toYaml .Values.podAnnotations | indent 8 }}
     spec:
       {{- if .Values.serviceAccount.create }}
       serviceAccountName: {{ .Values.serviceAccount.name }}

--- a/charts/schema-registry/values.yaml
+++ b/charts/schema-registry/values.yaml
@@ -51,6 +51,9 @@ container: {}
   # volume:
   #   mountPath: /additional_libs
 
+## Custom annotations to be applied to the POD
+podAnnotations: {}
+
 ## Ingress configuration.
 ingress:
   enabled: false


### PR DESCRIPTION
**Change log description**  
Updates the Helm chart to allow custom annotations to be expressed on the final Schema registry PODs

**Purpose of the change**  
Fixes #208 

**What the code does**  
Provides a `podAnnotations` value on the Helm chart allowing custom POD annotations to be expressed.  The value of the `podAnnotations` is copied to the final `deployment` template

**How to verify it**  
Using the following values file called "values.txt"
```
podAnnotations:
  first: one
  second: two
```
`helm install schema-registry charts/schema-registry --values values.txt`
The following shows the final output:
```
spec:
  progressDeadlineSeconds: 600
  replicas: 2
  revisionHistoryLimit: 10
  selector:
    matchLabels:
      app.kubernetes.io/name: schema-registry
  strategy:
    rollingUpdate:
      maxSurge: 25%
      maxUnavailable: 25%
    type: RollingUpdate
  template:
    metadata:
      annotations: <<<<<<<<<<<<<<<<<
        first: one
        second: two
      creationTimestamp: null
      labels:
        app.kubernetes.io/name: schema-registry
```
With no custom POD annotations specified:
```
  template:
    metadata:
      creationTimestamp: null
      labels:
        app.kubernetes.io/name: schema-registry
    spec:
```
