### PR TITLE
Issue 214:  publish snapshot to Git Hub Packages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,4 +94,4 @@ jobs:
             ${{github.ref}}-${{github.run_id}}
             ${{github.ref}}
       - name: Publish Snapshot
-        run: ./gradlew publish - PpublishUrl=https://maven.pkg.github.com/${{github.repository}} -PpublishUsername==${{github.actor}} -PpublishPassword=${{secrets.GITHUB_TOKEN}} ${{env.GRADLE_OPTS}}
+        run: ./gradlew publish -PpublishUrl=https://maven.pkg.github.com/${{github.repository}} -PpublishUsername==${{github.actor}} -PpublishPassword=${{secrets.GITHUB_TOKEN}} ${{env.GRADLE_OPTS}}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,7 +74,7 @@ jobs:
   snapshot:
     name: Artifactory Snapshot
     needs: [Build, Javadocs]
-    if: ${{ github.event_name == 'push' && (github.ref == 'ref/heads/master' || startsWith(github.ref, 'refs/heads/r0.') || startsWith(github.ref, 'refs/heads/r1.')) }}
+    # if: ${{ github.event_name == 'push' && (github.ref == 'ref/heads/master' || startsWith(github.ref, 'refs/heads/r0.') || startsWith(github.ref, 'refs/heads/r1.')) }}
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout
@@ -94,4 +94,4 @@ jobs:
             ${{github.ref}}-${{github.run_id}}
             ${{github.ref}}
       - name: Publish Snapshot
-        run: ./gradlew publish - PpublishUrl=jcenterSnapshot -PpublishUsername=${{secrets.BINTRAY_USER}} -PpublishPassword=${{secrets.BINTRAY_KEY}} ${{env.GRADLE_OPTS}}
+        run: ./gradlew publish - PpublishUrl=https://maven.pkg.github.com/${{github.repository}} -PpublishUsername==${{github.actor}} -PpublishPassword=${{secrets.GITHUB_TOKEN}} ${{env.GRADLE_OPTS}}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,7 +74,7 @@ jobs:
   snapshot:
     name: Artifactory Snapshot
     needs: [Build, Javadocs]
-    # if: ${{ github.event_name == 'push' && (github.ref == 'ref/heads/master' || startsWith(github.ref, 'refs/heads/r0.') || startsWith(github.ref, 'refs/heads/r1.')) }}
+    if: ${{ github.event_name == 'push' && (github.ref == 'ref/heads/master' || startsWith(github.ref, 'refs/heads/r0.') || startsWith(github.ref, 'refs/heads/r1.')) }}
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout


### PR DESCRIPTION
**Change log description**  

This changes the target location where optional snapshot are published.   Git Hub Packages versus Jcenter.

**Purpose of the change**  
Fixes #214 

Make schema registry snapshots available.

**What the code does**  

See description.

**How to verify it**  

See tests https://github.com/sarlaccpit/schema-registry/actions/runs/1079214284   
