### PR TITLE
Issue-209: updates netty and Keycloak client libraries

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -78,13 +78,16 @@ allprojects {
 
     repositories {
         mavenLocal()
-        jcenter()
         mavenCentral()
         maven {
-            url "https://oss.jfrog.org/jfrog-dependencies"
+            url "https://repository.apache.org/snapshots"
         }
         maven {
-            url "https://repository.apache.org/snapshots"
+            url "https://maven.pkg.github.com/pravega/pravega-keycloak"
+            credentials {
+                username = "pravega-public"
+                password = "\u0067\u0068\u0070\u005F\u0048\u0034\u0046\u0079\u0047\u005A\u0031\u006B\u0056\u0030\u0051\u0070\u006B\u0079\u0058\u006D\u0035\u0063\u0034\u0055\u0033\u006E\u0032\u0065\u0078\u0039\u0032\u0046\u006E\u0071\u0033\u0053\u0046\u0076\u005A\u0049"
+            }
         }
     }
 
@@ -116,6 +119,9 @@ allprojects {
             force "org.glassfish.jersey.core:jersey-server:" + jerseyVersion
             force "com.fasterxml.jackson.core:jackson-databind:" + jacksonVersion
             force "org.slf4j:slf4j-api:" + slf4jApiVersion
+            force "io.netty:netty-tcnative-boringssl-static:" + nettyBoringSSLVersion
+            force "io.netty:netty-transport:" + nettyVersion
+            force "io.netty:netty-handler:" + nettyVersion
         }
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -35,6 +35,8 @@ jerseyVersion=2.30
 junitVersion=4.12
 lombokVersion=1.18.4
 mockitoVersion=2.23.0
+nettyVersion=4.1.65.Final
+nettyBoringSSLVersion=2.0.39.Final
 jacocoVersion=0.8.2
 protobufGradlePlugin=0.8.9
 protobufProtocVersion=3.11.4
@@ -49,7 +51,7 @@ avroProtobufVersion=1.7.7
 snappyVersion=1.1.7.3
 javaxActivationVersion=1.1.1
 pravegaVersion=0.9.0
-pravegaKeyCloakVersion=0.9.0
+pravegaKeyCloakVersion=0.10.0-1.1816555-SNAPSHOT
 
 # Version and base tags can be overridden at build time
 schemaregistryVersion=0.3.0-SNAPSHOT

--- a/gradle.properties
+++ b/gradle.properties
@@ -51,7 +51,7 @@ avroProtobufVersion=1.7.7
 snappyVersion=1.1.7.3
 javaxActivationVersion=1.1.1
 pravegaVersion=0.9.0
-pravegaKeyCloakVersion=0.10.0-1.1816555-SNAPSHOT
+pravegaKeyCloakVersion=0.10.0-42.46eec40-SNAPSHOT
 
 # Version and base tags can be overridden at build time
 schemaregistryVersion=0.3.0-SNAPSHOT


### PR DESCRIPTION
**Change log description**  

This PR updates the Keycloak client to be in line with the Flink and Spark connectors that use a 0.10.0 snapshot of that library.
(consequently, a switch to use GH packages is also added since snapshots come from there now).

Most importantly, a force override of the netty libraries is added such that the same runtime versions as Pravega client are used.  This allows TLS1.3 connections to be possible

**Purpose of the change**  

Fixes https://github.com/pravega/schema-registry/issues/209

**What the code does**  

See description

**How to verify it**  

Tested Schema registry in an environment where Pravega is deployed with TLS1.3 connectivity only.

Tested with a test program that the schema registry client is not affected by this.
