### PR TITLE
Issue 217: fix master branch refs typo in GH action condition

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,7 +74,7 @@ jobs:
   snapshot:
     name: Artifactory Snapshot
     needs: [Build, Javadocs]
-    if: ${{ github.event_name == 'push' && (github.ref == 'ref/heads/master' || startsWith(github.ref, 'refs/heads/r0.') || startsWith(github.ref, 'refs/heads/r1.')) }}
+    if: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/r0.') || startsWith(github.ref, 'refs/heads/r1.')) }}
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout


### PR DESCRIPTION
Signed-off-by: Christophe Balczunas <christophe.balczunas@emc.com>

**Change log description**  

Typo in GH action condition causes snapshots to be skipped even with a push to master branch.


**Purpose of the change**  

Fixes #217 .  Enables snapshots for master branch.

**What the code does**  
Fixed the typo.

**How to verify it**  

Unfortunately, there is no easy way to validate it until it gets merged to master.
