### PR TITLE
Update SR config properties with correct auth token

### DIFF
--- a/server/src/conf/schema-registry.config.properties
+++ b/server/src/conf/schema-registry.config.properties
@@ -23,7 +23,7 @@ schemaRegistry.store.pravega.controller.connect.uri=${CONTROLLER_URL}
 schemaRegistry.store.pravega.controller.connect.security.tls.trustStore.location=${CONTROLLER_TLS_TRUST_STORE}
 schemaRegistry.store.pravega.controller.connect.security.tls.validateHostName.enable=${CONTROLLER_TLS_VALIDATE_HOSTNAME}
 schemaRegistry.store.pravega.controller.connect.auth.method=${CONTROLLER_AUTH_METHOD}
-schemaRegistry.store.pravega.controller.connect.auth.token=${CONTROLLER_AUTH_METHOD}
+schemaRegistry.store.pravega.controller.connect.auth.token=${CONTROLLER_AUTH_TOKEN}
 
 ## TLS configuration
 schemaRegistry.security.tls.enable=${TLS_ENABLED}


### PR DESCRIPTION
Signed-off-by: Shashwat Sharma <shashwat_sharma@dell.com>

**Change log description**  
There is a typo in the SR config properties for the variable `schemaRegistry.store.pravega.controller.connect.auth.token` which is currently accepting the wrong value `CONTROLLER_AUTH_METHOD` while it should read `CONTROLLER_AUTH_TOKEN` instead.

**Purpose of the change**  
Fixes #229 

**What the code does**  
Update the conf property with correct value

