### PR TITLE
Issue 231: Prepare for 0.3.0 release

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -50,8 +50,8 @@ avroVersion=1.9.1
 avroProtobufVersion=1.10.2
 snappyVersion=1.1.7.3
 javaxActivationVersion=1.1.1
-pravegaVersion=0.10.0-2917.d58e537-SNAPSHOT
-pravegaKeyCloakVersion=0.10.0-42.46eec40-SNAPSHOT
+pravegaVersion=0.10.1
+pravegaKeyCloakVersion=0.10.1
 apacheZookeeperVersion=3.5.9
 
 # Version and base tags can be overridden at build time


### PR DESCRIPTION
**Change log description**  

 *   Update the Pravega version to 0.10.1
 *   Update the KeyCloak version to 0.10.1.


**Purpose of the change**  
Fixes #231 

**What the code does**  
 *   Update the Pravega version to 0.10.1
 *   Update the KeyCloak version to 0.10.1.

**How to verify it**  
All the existing tests should pass.
