### PR TITLE
Issue 240: Remove Netty dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -126,8 +126,6 @@ allprojects {
             force "org.glassfish.jersey.core:jersey-server:" + jerseyVersion
             force "org.slf4j:slf4j-api:" + slf4jApiVersion
             force "io.netty:netty-tcnative-boringssl-static:" + nettyBoringSSLVersion
-            force "io.netty:netty-transport:" + nettyVersion
-            force "io.netty:netty-handler:" + nettyVersion
             force "org.apache.zookeeper:zookeeper:" + apacheZookeeperVersion
         }
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -35,7 +35,6 @@ jerseyVersion=2.30
 junitVersion=4.12
 lombokVersion=1.18.4
 mockitoVersion=2.23.0
-nettyVersion=4.1.65.Final
 nettyBoringSSLVersion=2.0.39.Final
 jacocoVersion=0.8.2
 protobufGradlePlugin=0.8.9


### PR DESCRIPTION
Signed-off-by: Shashwat Sharma <shashwat_sharma@dell.com>

**Change log description**  
Remove forced netty version from build.gradle causing conflicts with Pravega higher versions

**Purpose of the change**  
fixes #240 

**How to verify it**  
The build should pass and all existing test cases should complete successfully
