### PR TITLE
Issue 244: Prepare for 0.4.0 release

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -49,9 +49,9 @@ avroVersion=1.11.0
 avroProtobufVersion=1.10.2
 snappyVersion=1.1.7.3
 javaxActivationVersion=1.1.1
-pravegaVersion=0.10.1
-pravegaKeyCloakVersion=0.10.1
-apacheZookeeperVersion=3.5.9
+pravegaVersion=0.11.0
+pravegaKeyCloakVersion=0.11.0
+apacheZookeeperVersion=3.6.3
 
 # Version and base tags can be overridden at build time
 schemaregistryVersion=0.4.0-SNAPSHOT


### PR DESCRIPTION
**Change log description**  
Update the Pravega  and KeyCloak version to 0.11.0. Also, upgraded Zookeeper version due to dependency conflict.

**Purpose of the change**  
Fixes #244.

**What the code does**  
Update the Pravega  and KeyCloak version to 0.11.0. Also, upgraded Zookeeper version due to dependency conflict.

**How to verify it**  
Build must pass.

Signed-off-by: Raúl Gracia <raul.gracia@emc.com>