### PR TITLE
Issue 246: Update branch version to 0.4.0 in r0.4 branch

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -54,7 +54,7 @@ pravegaKeyCloakVersion=0.11.0
 apacheZookeeperVersion=3.6.3
 
 # Version and base tags can be overridden at build time
-schemaregistryVersion=0.4.0-SNAPSHOT
+schemaregistryVersion=0.4.0
 schemaregistryBaseTag=pravega/schemaregistry
 
 # Pravega Signing Key


### PR DESCRIPTION
**Change log description**  
Set schema registry version to 0.4.0.

**Purpose of the change**  
Fixes #246.

**What the code does**  
Set schema registry version to 0.4.0.

**How to verify it**  
Build must pass.

Signed-off-by: Raúl Gracia <raul.gracia@emc.com>