### PR TITLE
Issue 248: Upgrade Schema Registry version to 0.5.0-SNAPSHOT

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -54,7 +54,7 @@ pravegaKeyCloakVersion=0.11.0
 apacheZookeeperVersion=3.6.3
 
 # Version and base tags can be overridden at build time
-schemaregistryVersion=0.4.0-SNAPSHOT
+schemaregistryVersion=0.5.0-SNAPSHOT
 schemaregistryBaseTag=pravega/schemaregistry
 
 # Pravega Signing Key


### PR DESCRIPTION
**Change log description**  
Promote master to 0.5-snapshot as part of 0.4 release.

**Purpose of the change**  
Fixes #248.

**What the code does**  
Promote master to 0.5-snapshot as part of 0.4 release.

**How to verify it**  
Build must pass.

Signed-off-by: Raúl Gracia <raul.gracia@emc.com>