### PR TITLE
Updated default coordinator URI and image tag in helm chart values.yaml

### DIFF
--- a/charts/schema-registry/values.yaml
+++ b/charts/schema-registry/values.yaml
@@ -79,7 +79,7 @@ client:
 
 logLevel: INFO
 storeType: Pravega
-controllerUri: tcp://localhost:9090
+controllerUri: tcp://pravega-pravega-controller:9090
 pravega:
   ## following values should be configured if TLS is required for
   ## talking to pravega and we want to perform server auth certificate

--- a/charts/schema-registry/values.yaml
+++ b/charts/schema-registry/values.yaml
@@ -16,7 +16,7 @@ replicas: 2
 
 image:
   repository: pravega/schemaregistry
-  tag: 0.2.0
+  tag: 0.4.0
   pullPolicy: IfNotPresent
 
 ## Service account name and whether to create it.

--- a/gradle.properties
+++ b/gradle.properties
@@ -54,7 +54,7 @@ pravegaKeyCloakVersion=0.11.0
 apacheZookeeperVersion=3.6.3
 
 # Version and base tags can be overridden at build time
-schemaregistryVersion=0.4.0-SNAPSHOT
+schemaregistryVersion=0.5.0-SNAPSHOT
 schemaregistryBaseTag=pravega/schemaregistry
 
 # Pravega Signing Key

--- a/gradle.properties
+++ b/gradle.properties
@@ -49,9 +49,9 @@ avroVersion=1.11.0
 avroProtobufVersion=1.10.2
 snappyVersion=1.1.7.3
 javaxActivationVersion=1.1.1
-pravegaVersion=0.10.1
-pravegaKeyCloakVersion=0.10.1
-apacheZookeeperVersion=3.5.9
+pravegaVersion=0.11.0
+pravegaKeyCloakVersion=0.11.0
+apacheZookeeperVersion=3.6.3
 
 # Version and base tags can be overridden at build time
 schemaregistryVersion=0.4.0-SNAPSHOT


### PR DESCRIPTION
**Change log description**  

Updated the default Controller URI to match the default pravega helm charts since localhost would not be valid given the image used in the k8 helm chart environment. 

**Purpose of the change**  

Addresses #250

This PR allows the schema registry helm charts to be compatible with the Pravega helm charts when following the [Pravega Kubernetes 101 Guide](https://cncf.pravega.io/docs/nightly/getting-started/pravega-on-kubernetes-101/).

The guide states to install the pravega charts via the pravega release name: `helm install pravega pravega/pravega --version=0.8.0`, which will default to creating the controller service in the ClusterIP with the internal dns of "pravega-pravega-controller".

**What the code does**  

No code change, just default configuration.

**How to verify it**  

Follow the  [Pravega Kubernetes 101 Guide](https://cncf.pravega.io/docs/nightly/getting-started/pravega-on-kubernetes-101/) and then install the schema registry charts with default values.