### PR TITLE
Issue-250 Default Helm Chart value for controllerUri

### DIFF
--- a/charts/schema-registry/values.yaml
+++ b/charts/schema-registry/values.yaml
@@ -16,7 +16,7 @@ replicas: 2
 
 image:
   repository: pravega/schemaregistry
-  tag: 0.2.0
+  tag: 0.4.0
   pullPolicy: IfNotPresent
 
 ## Service account name and whether to create it.
@@ -79,7 +79,7 @@ client:
 
 logLevel: INFO
 storeType: Pravega
-controllerUri: tcp://localhost:9090
+controllerUri: tcp://pravega-pravega-controller:9090
 pravega:
   ## following values should be configured if TLS is required for
   ## talking to pravega and we want to perform server auth certificate


### PR DESCRIPTION
Signed-off-by: Shashwat Sharma <shashwat_sharma@dell.com>

**Change log description**  
Updated the default Controller URI to match the default pravega helm charts since localhost would not be valid given the image used in the k8 helm chart environment.

**Purpose of the change**  
Fixes #250 

**What the code does**  
Updates the default controllerUri value in values.yaml file

**How to verify it**  
Follow the [Pravega Kubernetes 101 Guide](https://cncf.pravega.io/docs/nightly/getting-started/pravega-on-kubernetes-101/) and then install the schema registry charts with default values.
