### PR TITLE
Issue 261: Compress distribution tar files using gzip

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -635,6 +635,10 @@ distributions {
 
 }
 
+tasks.withType(Tar) {
+    compression = Compression.GZIP
+}
+
 task sourceCopy(type: Copy) {
     from rootDir
     into 'source'


### PR DESCRIPTION
**Change log description**  
Produce compressed .tgz release assets instead of uncompressed .tar assets.

**Purpose of the change**  
Fixes #261

**What the code does**  
Sets gzip as the compression for Tar tasks in the gradle build.

**How to verify it**  
`./gradlew clean distribution` and note *.tgz files in `build/distribution`.