### PR TITLE
Issue-263 Update Schema Registry Release Version in charts

### DIFF
--- a/charts/schema-registry/Chart.yaml
+++ b/charts/schema-registry/Chart.yaml
@@ -12,6 +12,6 @@ apiVersion: v2
 name: schema-registry
 description: Schema Registry Helm chart for Kubernetes
 type: application
-version: 0.2.0
-appVersion: 0.2.0
+version: 0.5.0
+appVersion: 0.5.0
 home: https://github.com/pravega/schema-registry

--- a/charts/schema-registry/values.yaml
+++ b/charts/schema-registry/values.yaml
@@ -16,7 +16,7 @@ replicas: 2
 
 image:
   repository: pravega/schemaregistry
-  tag: 0.4.0
+  tag: 0.5.0
   pullPolicy: IfNotPresent
 
 ## Service account name and whether to create it.

--- a/documentation/src/docs/pravega-applications.md
+++ b/documentation/src/docs/pravega-applications.md
@@ -22,7 +22,7 @@ all:
  <dependency>
         <groupId>io.pravega</groupId>
             <artifactId>schemaregistry-serializers</artifactId>
-            <version>0.2.0</version>
+            <version>0.5.0</version>
  </dependency>
 
 json only:

--- a/documentation/src/docs/pravega-applications.md
+++ b/documentation/src/docs/pravega-applications.md
@@ -29,21 +29,21 @@ json only:
  <dependency>
         <groupId>io.pravega</groupId>
             <artifactId>schemaregistry-serializers-json</artifactId>
-            <version>0.2.0</version>
+            <version>0.5.0</version>
  </dependency>
 
 avro only:
  <dependency>
         <groupId>io.pravega</groupId>
             <artifactId>schemaregistry-serializers-avro</artifactId>
-            <version>0.2.0</version>
+            <version>0.5.0</version>
  </dependency>
 
 protobuf only:
  <dependency>
         <groupId>io.pravega</groupId>
             <artifactId>schemaregistry-serializers-protobuf</artifactId>
-            <version>0.2.0</version>
+            <version>0.5.0</version>
  </dependency>
 ```
 


### PR DESCRIPTION
Signed-off-by: Shashwat Sharma <shashwat_sharma@dell.com>

**Change log description**  
Current version of charts and values.yaml uses the older release of Schema Registry. This needs to be updated to current version.

**Purpose of the change**  
Fixes #263 

**What the code does**  
Update the version of current Schema Registry in charts and values.yaml

**How to verify it**  
Current version(0.5.0) should be reflected in the charts and values.yaml with updated version ref in Pravega-Applications.md
