### PR TITLE
Issue 267: Promote master to 0.6.0-Snapshot

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -54,7 +54,7 @@ pravegaKeyCloakVersion=0.12.0
 apacheZookeeperVersion=3.6.3
 
 # Version and base tags can be overridden at build time
-schemaregistryVersion=0.5.0-SNAPSHOT
+schemaregistryVersion=0.6.0-SNAPSHOT
 schemaregistryBaseTag=pravega/schemaregistry
 
 # Pravega Signing Key


### PR DESCRIPTION
Signed-off-by: Shashwat Sharma <shashwat_sharma@dell.com>

Change log description
Promote master to 0.6-snapshot as 0.5 is released.

Purpose of the change
Fixes #267 .

What the code does
Promote master to 0.6-snapshot.

How to verify it
Build must pass.