### PR TITLE
Issue 271: Bump r0.5 to 0.5.1-SNAPSHOT

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -54,7 +54,7 @@ pravegaKeyCloakVersion=0.12.0
 apacheZookeeperVersion=3.6.3
 
 # Version and base tags can be overridden at build time
-schemaregistryVersion=0.5.0-SNAPSHOT
+schemaregistryVersion=0.5.1-SNAPSHOT
 schemaregistryBaseTag=pravega/schemaregistry
 
 # Pravega Signing Key


### PR DESCRIPTION
**Change log description**  
Set Schema Registry version to 0.5.1-SNAPSHOT.

**Purpose of the change**  
Fixes #271.

**What the code does**  
Set Schema Registry version to 0.5.1-SNAPSHOT.

**How to verify it**  
Build should pass.
