### PR TITLE
Issue 283: Upgrade Schema Registry version to 0.7.0-SNAPSHOT

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -55,7 +55,7 @@ apacheZookeeperVersion=3.6.3
 snakeYamlVersion=2.0
 
 # Version and base tags can be overridden at build time
-schemaregistryVersion=0.6.0-SNAPSHOT
+schemaregistryVersion=0.7.0-SNAPSHOT
 schemaregistryBaseTag=pravega/schemaregistry
 
 # Pravega Signing Key


### PR DESCRIPTION
**Change log description**
Promote master to 0.7-snapshot as part of 0.6 release.

**Purpose of the change**
Fixes #283 .

**What the code does**
Promote master to 0.7-snapshot as part of 0.6 release.

**How to verify it**
Build must pass.