### PR TITLE
Issue 285: Prepare Schema Registry for 0.6 release

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -49,13 +49,13 @@ avroVersion=1.11.1
 avroProtobufVersion=1.10.2
 snappyVersion=1.1.7.3
 javaxActivationVersion=1.1.1
-pravegaVersion=0.12.0
-pravegaKeyCloakVersion=0.12.0
+pravegaVersion=0.13.0
+pravegaKeyCloakVersion=0.13.0
 apacheZookeeperVersion=3.6.3
 snakeYamlVersion=2.0
 
 # Version and base tags can be overridden at build time
-schemaregistryVersion=0.6.0-SNAPSHOT
+schemaregistryVersion=0.6.0
 schemaregistryBaseTag=pravega/schemaregistry
 
 # Pravega Signing Key


### PR DESCRIPTION
**Change log description**  
Update the Pravega and KeyCloak version to 0.13.0 and SR version to 0.6.0

**Purpose of the change**  
Fixes #285 

**What the code does**  
Update the Pravega, KeyCloak and SR version

**How to verify it**  
The build must pass